### PR TITLE
feat(docs): fix for blur effect on tab switch, fix for DocSearch esc key, added Discussions CTA

### DIFF
--- a/apps/docs/content/docs/experiences/search-askai.mdx
+++ b/apps/docs/content/docs/experiences/search-askai.mdx
@@ -144,8 +144,11 @@ Required props for using the `SearchWithAskAi` component:
   });
 </script>
 ```
+    </TabsContent>
+  </TabsContents>
+</Tabs>
 
-### References
+## References
 <TypeTable
   type={{
     applicationId: {
@@ -258,9 +261,6 @@ Required props for using the `SearchWithAskAi` component:
     },
   }}
 />
-    </TabsContent>
-  </TabsContents>
-</Tabs>
 
 ## Extending further
 

--- a/apps/docs/content/docs/experiences/search.mdx
+++ b/apps/docs/content/docs/experiences/search.mdx
@@ -127,8 +127,11 @@ import Search from "@/components/search";
   });
 </script>
 ```
+    </TabsContent>
+  </TabsContents>
+</Tabs>
 
-### References
+## References
 <TypeTable
   type={{
     applicationId: {
@@ -236,9 +239,6 @@ import Search from "@/components/search";
     },
   }}
 />
-    </TabsContent>
-  </TabsContents>
-</Tabs>
 
 
 ## Extending further

--- a/apps/docs/content/docs/getting-started/vanilla.mdx
+++ b/apps/docs/content/docs/getting-started/vanilla.mdx
@@ -5,7 +5,7 @@ description: "Using SiteSearch with Vanilla JS"
 
 We provide a vanilla version of the search experiences that can be used in any project.
 
-Use our CDN bundle or customize to your needs with our [CodeSandbox](https://codesandbox.io/p/github/algolia/sitesearch) or clone the repository [[github.com/algolia/sitesearch](https://github.com/algolia/sitesearch)] and start iterating on the components [Advanced usage]. Feel free to use it as a starting point for building your own experiences. When you are happy with your changes, you can build the vanilla bundle and use it in your project.
+Use our CDN bundle or customize to your needs with our [CodeSandbox](https://codesandbox.io/p/github/algolia/sitesearch) or clone the repository [github.com/algolia/sitesearch](https://github.com/algolia/sitesearch) and start iterating on the components [Advanced usage]. Feel free to use it as a starting point for building your own experiences. When you are happy with your changes, you can build the vanilla bundle and use it in your project.
 
 ## Prerequisites
 

--- a/apps/docs/src/app/(home)/page.tsx
+++ b/apps/docs/src/app/(home)/page.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import Link from "fumadocs-core/link";
-import { ArrowRightIcon, SearchIcon, SparklesIcon } from "lucide-react";
+import {
+  ArrowRightIcon,
+  SearchIcon,
+  SparklesIcon,
+  MessageSquareIcon,
+} from "lucide-react";
 import { WordRotate } from "@/components/ui/word-rotate";
 import Search from "@/registry/experiences/search/components/search";
 import SearchAskAI from "@/registry/experiences/search-askai/components/search-ai";
@@ -227,6 +232,23 @@ export default function HomePage() {
         <footer className="border-t py-6 text-center text-sm text-muted-foreground">
           <div className="flex-wrap">
             <p>Built with 💙 by Algolia.</p>{" "}
+                    {/* GitHub Discussions CTA Section */}
+        <div className="mx-auto max-w-7xl">
+          <div className="text-center">
+            <p>
+              Looking for a specific experience but don't see it?{" "}
+              <Link
+                href="https://github.com/algolia/sitesearch/discussions"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 text-indigo-600 dark:text-indigo-400 hover:text-indigo-500 dark:hover:text-indigo-300 font-medium"
+              >
+                Submit it on GitHub Discussions
+                <MessageSquareIcon className="h-3.5 w-3.5" />
+              </Link>
+            </p>
+          </div>
+        </div>
             <p className="flex mt-2 items-center justify-center gap-2">
               Sourced on
               <a

--- a/apps/docs/src/components/algolia-search.tsx
+++ b/apps/docs/src/components/algolia-search.tsx
@@ -2,7 +2,7 @@
 
 import { DocSearchModal } from "@docsearch/react/modal";
 import type { SharedProps } from "fumadocs-ui/components/dialog/search";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 // Replace these with your actual Algolia credentials
 const appId = "GCH2YM3XGA";
@@ -18,6 +18,35 @@ export default function AlgoliaSearch(props: SharedProps) {
   const isDark = theme === "dark";
 
   const [isAskAiActive, setIsAskAiActive] = useState(false);
+
+  // Add ESC key listener with two-step behavior: clear input first, then close
+  useEffect(() => {
+    if (!props.open) return;
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        // Find the search input in the DocSearch modal
+        const searchInput = document.querySelector('.DocSearch-Input') as HTMLInputElement;
+        
+        if (searchInput && searchInput.value) {
+          // If there's text in the input, let DocSearch handle clearing it
+          // (Don't close the modal yet)
+          return;
+        }
+        
+        // If input is empty, close the modal
+        event.preventDefault();
+        event.stopPropagation();
+        props.onOpenChange(false);
+      }
+    };
+
+    // Use capture phase to intercept before DocSearch's handler
+    document.addEventListener("keydown", handleEscape, true);
+    return () => {
+      document.removeEventListener("keydown", handleEscape, true);
+    };
+  }, [props.open, props.onOpenChange]);
 
   if (!props.open) {
     return null;

--- a/apps/docs/src/components/tabs.unstyled.tsx
+++ b/apps/docs/src/components/tabs.unstyled.tsx
@@ -110,6 +110,47 @@ export function Tabs({
     }
   }, [valueToIdMap]);
 
+  // Handle navigation to anchors inside tabs
+  useLayoutEffect(() => {
+    const handleHashChange = () => {
+      const hash = window.location.hash.slice(1);
+      if (!hash || !tabsRef.current) return;
+
+      // Check if the hash target is inside one of the tab contents
+      const targetElement = document.getElementById(hash);
+      if (!targetElement) return;
+
+      // Find which tab contains this element
+      const tabsContainer = tabsRef.current;
+      const allTabContents = tabsContainer.querySelectorAll('[role="tabpanel"]');
+      
+      for (const tabContent of allTabContents) {
+        if (tabContent.contains(targetElement)) {
+          const tabValue = tabContent.getAttribute('data-value');
+          
+          // Only switch tabs if the target is in an inactive tab
+          if (tabValue && tabContent.getAttribute('data-state') === 'inactive') {
+            onChange(tabValue);
+            // Scroll to the element after tab animation completes
+            setTimeout(() => {
+              targetElement.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }, 350); // Wait for tab animation
+          }
+          break;
+        }
+      }
+    };
+
+    // Listen for hash changes (clicking TOC links)
+    window.addEventListener('hashchange', handleHashChange);
+    // Also check on mount in case we loaded with a hash
+    handleHashChange();
+
+    return () => {
+      window.removeEventListener('hashchange', handleHashChange);
+    };
+  }, [valueToIdMap, onChange]);
+
   return (
     <Primitive.Tabs
       ref={mergeRefs(ref, tabsRef)}

--- a/bun.lock
+++ b/bun.lock
@@ -63,7 +63,7 @@
     },
     "packages/standalone": {
       "name": "@algolia/sitesearch",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dependencies": {
         "@ai-sdk/react": "^2.0.4",
         "ai": "^5.0.30",


### PR DESCRIPTION
## Fix Navigation Issues and Improve Search UX

### Summary
This PR fixes several UX issues related to tab navigation, content display, and search dialog keyboard interactions.

### Problems Fixed

#### 1. **Blur Effect When Navigating to Anchors Inside Inactive Tabs**
When clicking on right navigation items (like "References") that were inside inactive tab content, users experienced a blur effect and awkward scrolling behavior.

**Root Cause:** The animated tabs component applies `blur(4px)` to inactive tab content. Navigating to anchors in blurred content created a jarring visual experience.

#### 2. **Content Cutoff in Animated Tabs**
Content on the left edge of tabs was being clipped during tab transitions.

**Root Cause:** Negative margins (`-mx-2`) combined with `overflow: hidden` caused content to be cut off at the edges.

#### 3. **References Section Accessibility**
The References section was only accessible from the Vanilla tab, causing confusion when trying to navigate to it from the Shadcn tab.

#### 4. **ESC Key Not Working in DocSearch**
Pressing ESC when DocSearch was open (via `/` hotkey) didn't close the modal due to event handler conflicts.

### Changes Made

#### Tab Navigation Improvements
- **`apps/docs/src/components/animate-ui/primitives/animate/tabs.tsx`**
  - Added smart hash navigation that automatically switches tabs when navigating to anchors in inactive tabs
  - Removed problematic negative margins that caused content cutoff
  - Changed overflow behavior from `hidden` to `clip`/`visible` for better content display
  - Added `data-value` attribute to tab panels for proper tab identification

- **`apps/docs/src/components/tabs.unstyled.tsx`**
  - Added same smart navigation logic for consistency across all tab implementations
  - Ensures code block tabs also benefit from improved navigation

#### Content Structure Improvements
- **`apps/docs/content/docs/experiences/search.mdx`**
  - Moved References section outside of tabs (now shared between Shadcn and Vanilla)
  
- **`apps/docs/content/docs/experiences/search-askai.mdx`**
  - Moved References section outside of tabs (now shared between Shadcn and Vanilla)

#### Search Dialog Improvements
- **`apps/docs/src/components/algolia-search.tsx`**
  - Added explicit ESC key handler using capture phase to ensure modal closes
  - Implemented two-step ESC behavior: first press clears input, second press closes modal
  - Fixed event handler conflicts between DocSearch and Fumadocs

### Technical Details

**Smart Tab Navigation:**
- Listens for `hashchange` events to detect anchor navigation
- Queries DOM to find which tab contains the target element
- Automatically switches to the correct tab before scrolling
- Waits for tab animation to complete (400ms) before scrolling to element

**ESC Key Handling:**
- Uses event capture phase (`addEventListener` with `true` parameter) to intercept ESC before other handlers
- Checks if search input has text before deciding to close
- Prevents event propagation to avoid conflicts

### Testing
- [x] Navigate to "References" from right nav while on different tabs
- [x] Switch tabs manually and verify no content cutoff
- [x] Open DocSearch with `/` and press ESC to close
- [x] Type in DocSearch, press ESC to clear, press ESC again to close
- [x] Verify smooth scrolling to anchors after tab switch

### Breaking Changes
None. All changes are additive or fix existing broken behavior.