### PR TITLE
docs: regularize capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # Algolia SiteSearch
 
-🫆 Opinionated search experiences for your search needs, powered by Algolia's [Instant Search](https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/js/) and [AskAI](https://www.algolia.com/products/ai/ask-ai)
+🫆 Opinionated search experiences for your search needs, powered by Algolia's [InstantSearch](https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/js/) and [Ask AI](https://www.algolia.com/products/ai/ask-ai)
 
 ## Overview
 
 SiteSearch provides opinionated search components that showcases Algolia's lightning-fast search capabilities in the form of experiences. Available as both React implementations and Vanilla JavaScript, it offers a complete search solution that can be integrated into any modern web application.
 
-### Key Features
+### Key features
 
-- **⚡ Instant Search** - Sub-50ms search powered by Algolia's global infrastructure
+- **⚡ Instant search** - Sub-50ms search powered by Algolia's global infrastructure
 - **🎨 Extensible** - UI with comprehensive theming system
-- **🤖 AI-Enhanced** - Conversational chat interface for complex queries using [Ask AI](https://www.algolia.com/products/ai/ask-ai)
+- **🤖 AI-enhanced** - Conversational chat interface for complex queries using [Ask AI](https://www.algolia.com/products/ai/ask-ai)
 - **♿ Accessible** - WCAG 2.1 AA compliant with screen reader support & full keyboard navigation with customizable shortcuts
-- **📦 Framework Agnostic** - Works with React and bundles to vanilla JS to use anywhere
+- **📦 Framework agnostic** - Works with React and bundles to vanilla JS to use anywhere
 
 ## Pre-requisites
 
@@ -20,9 +20,9 @@ SiteSearch provides opinionated search components that showcases Algolia's light
 2. Setup an index – grab the [Index name](https://dashboard.algolia.com/indices) and [Search API key](https://dashboard.algolia.com/account/api-keys)
 3. [Optional] Create an [Ask AI assistant](https://dashboard.algolia.com/apps/ask-ai) (only if you need Ask AI)
 
-## Quick Start
+## Quickstart
 
-Follow instructions on the [SiteSearch Documentation Website](https://sitesearch.algolia.com)
+Follow the instructions in the [SiteSearch documentation](https://sitesearch.algolia.com)
 
 ## Theming
 

--- a/apps/docs/content/docs/experiences/ask-ai/highlight-to-askai.mdx
+++ b/apps/docs/content/docs/experiences/ask-ai/highlight-to-askai.mdx
@@ -15,12 +15,11 @@ Leverage [Algolia Ask AI](https://www.algolia.com/products/ai/ask-ai)'s context 
 ## Use cases
 
 - Documentation websites
-- Interactive blog posts & tutorials
+- Interactive blog posts and tutorials
 
 ## Preview
 
 <PreviewHighlightToAskAI />
-
 
 <Tabs>
   <div className="flex items-center justify-between gap-2 mt-20 mb-2">
@@ -68,10 +67,10 @@ Required props for using the `HighlightToAskAi` component:
 - `assistantId`: The Ask AI assistant ID
 
 Optional props:
+
 - `excludeElements`: An array of HTML elements to exclude from the highlighted text.
 - `askButtonLabel`: The label for the ask button.
 - `onAsk`: A callback function that will be called when the ask button is clicked.
-
 
 ### Structure
 
@@ -95,3 +94,4 @@ Optional props:
 
 - Change the styling to match your brand
 - Open in v0 for more customization
+

--- a/apps/docs/content/docs/experiences/dropdown-search.mdx
+++ b/apps/docs/content/docs/experiences/dropdown-search.mdx
@@ -82,6 +82,7 @@ import DropdownSearch from "@/components/dropdown-search";
 - **No modal**: Stays inline with your layout
 
 ## References
+
 <TypeTable
   type={{
     applicationId: {
@@ -158,4 +159,3 @@ import DropdownSearch from "@/components/dropdown-search";
 - Customize the dropdown appearance via Radix Popover props
 - Add custom behavior on item selection
 - Open in v0 for more customization
-

--- a/apps/docs/content/docs/experiences/search-askai.mdx
+++ b/apps/docs/content/docs/experiences/search-askai.mdx
@@ -65,7 +65,6 @@ Required props for using the `SearchWithAskAi` component:
 - `indexName`: The Algolia index name
 - `assistantId`: The Ask AI assistant ID
 
-
 ### Structure
 
 <Files>
@@ -86,6 +85,7 @@ Required props for using the `SearchWithAskAi` component:
     <TabsContent value="vanilla">
 
 ### Use our CDN bundle (recommended)
+
 ```html
 <link rel="stylesheet" href="https://unpkg.com/@algolia/sitesearch@latest/dist/search-askai.min.css" />
 <div id="search-container"></div>
@@ -108,8 +108,8 @@ Required props for using the `SearchWithAskAi` component:
 </script>
 ```
 
-
 ### Build your own bundle (advanced)
+
 - Open [CodeSandbox](https://codesandbox.io/p/github/algolia/sitesearch).
 - Update the experience in `packages/standalone` to fit your needs (requires React skills)
 - Build the bundle `bun run bundle`
@@ -144,11 +144,13 @@ Required props for using the `SearchWithAskAi` component:
   });
 </script>
 ```
+
     </TabsContent>
   </TabsContents>
 </Tabs>
 
 ## References
+
 <TypeTable
   type={{
     applicationId: {
@@ -266,3 +268,4 @@ Required props for using the `SearchWithAskAi` component:
 
 - Change the styling to match your brand
 - Open in v0 for more customization
+

--- a/apps/docs/content/docs/experiences/search.mdx
+++ b/apps/docs/content/docs/experiences/search.mdx
@@ -1,6 +1,6 @@
 ---
 title: Search
-description: "The default opinionated search experience built."
+description: "The default opinionated search experience."
 ---
 
 import { File, Folder, Files } from 'fumadocs-ui/components/files';
@@ -71,6 +71,7 @@ import Search from "@/components/search";
     <TabsContent value="vanilla">
 
 ### Use our CDN bundle (recommended)
+
 ```html
 <link rel="stylesheet" href="https://unpkg.com/@algolia/sitesearch@latest/dist/search.min.css" />
 <div id="search-container"></div>
@@ -92,8 +93,8 @@ import Search from "@/components/search";
 </script>
 ```
 
-
 ### Build your own bundle (advanced)
+
 - Open [CodeSandbox](https://codesandbox.io/p/github/algolia/sitesearch).
 - Update the experience in `packages/standalone` to fit your needs (requires React skills)
 - Build the bundle `bun run bundle`
@@ -127,11 +128,13 @@ import Search from "@/components/search";
   });
 </script>
 ```
+
     </TabsContent>
   </TabsContents>
 </Tabs>
 
 ## References
+
 <TypeTable
   type={{
     applicationId: {
@@ -240,7 +243,6 @@ import Search from "@/components/search";
   }}
 />
 
-
 ## Extending further
 
 - Integrate Algolia Recommend for related product below the hit list.
@@ -249,3 +251,4 @@ import Search from "@/components/search";
 - Add a `SearchEmpty` slot to highlight help center content or contact actions when no results surface.
 - Shape it to infinity with full support for `react-instantsearch`.
 - Open in v0 for AI edits.
+

--- a/apps/docs/content/docs/getting-started/react-shadcn.mdx
+++ b/apps/docs/content/docs/getting-started/react-shadcn.mdx
@@ -3,7 +3,7 @@ title: SiteSearch with Shadcn/UI
 description: "Using SiteSearch with Shadcn/UI"
 ---
 
-Like shadcn/ui, everything lives in your repo. You can read the source, edit it, and ship variants that match your product’s tone of voice.
+Like shadcn/ui, everything lives in your repo. You can read the source, edit it, and ship variants that match your product.
 
 ## Prerequisites
 
@@ -11,9 +11,9 @@ Like shadcn/ui, everything lives in your repo. You can read the source, edit it,
 - A React project, version 18 or later
 - [Other algolia prerequisites](/docs#prerequisites)
 
-<Callout title="Important">Make sure you have a setup Tailwind CSS in your project, shadcn/ui uses Tailwind CSS for styling and the CSS Variables mode for theming.</Callout>
+<Callout title="Important">Make sure you have a setup Tailwind CSS in your project, shadcn/ui uses Tailwind CSS for styling and the CSS variables mode for theming.</Callout>
 
-## Installing components & experiences
+## Installing components and experiences
 
 You can install our search experiences using the standard shadcn/ui CLI. This adds the selected component's code and any needed dependencies to your project. For example, to install the default SiteSearch experience, you would run:
 
@@ -23,4 +23,4 @@ npx shadcn@latest add @algolia/search
 
 This will add the `Search` component to your project under `components/search`. Proceed to use it as described in the [Search experience](/docs/experiences/search) documentation.
 
-All the components are built with the Shadcn/UI theming system, so you can easily customize the look and feel to match your brand.
+All components are built with the shadcn/ui theming system, so you can easily customize the look and feel to match your brand.

--- a/apps/docs/content/docs/getting-started/vanilla.mdx
+++ b/apps/docs/content/docs/getting-started/vanilla.mdx
@@ -56,8 +56,6 @@ We provide bundled version & hosted versions of the all the vanilla search exper
 
 <Callout title="Note">Always use the minified version of the experience to reduce the size of the bundle. (`.min.css` and `.min.js`).</Callout>
 
-
-
 ### Resources
 
 1. The [@algolia/sitesearch npm package](https://www.npmjs.com/package/@algolia/sitesearch)

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -14,7 +14,7 @@ Everything lives in your repo. You can read the source, fork it, and ship varian
 - [Algolia account](https://dashboard.algolia.com/)
 - [Algolia index](https://dashboard.algolia.com/indices)
 - [Algolia API key](https://dashboard.algolia.com/api-keys)
-- [Algolia Ask AI assistant](https://dashboard.algolia.com/ask-ai) (optional – only if you want to use Conversational Search)
+- [Algolia Ask AI assistant](https://dashboard.algolia.com/ask-ai) (optional – only if you want to use conversational search)
 
 ## Why we built this
 
@@ -22,8 +22,9 @@ Everything lives in your repo. You can read the source, fork it, and ship varian
 - **Stay flexible:** Every component ships uncompiled. Change the layout, switch styling systems, or replace logic as your product evolves.
 - **First-class Algolia:** We bake in search, insights, and AI answer patterns using Algolia best practices.
 
-## How get started
+## How to get started
 
-Get started following any of the following paths:
-  - [SiteSearch with Shadcn/UI](/docs/getting-started/react-shadcn)
-  - [SiteSearch with Vanilla JS](/docs/getting-started/vanilla)
+Following any of these paths:
+
+- [SiteSearch with Shadcn/UI](/docs/getting-started/react-shadcn)
+- [SiteSearch with Vanilla JS](/docs/getting-started/vanilla)

--- a/apps/docs/content/docs/tools/index.mdx
+++ b/apps/docs/content/docs/tools/index.mdx
@@ -7,7 +7,7 @@ icon: Wrench
 
 ## Tools
 
-- [SiteSearch Playground](https://community.algolia.com/docsearch-playground/?ss=true)
-- [V0 Playground](https://v0.dev/chat/api/open?url=https://sitesearch.algolia.com/r/search.json)
-- [SiteSearch Codesandbox](https://codesandbox.io/p/github/algolia/sitesearch)
-- [SiteSearch Repository](https://github.com/algolia/sitesearch)
+- [SiteSearch playground](https://community.algolia.com/docsearch-playground/?ss=true)
+- [v0 playground](https://v0.dev/chat/api/open?url=https://sitesearch.algolia.com/r/search.json)
+- [SiteSearch CodeSandbox](https://codesandbox.io/p/github/algolia/sitesearch)
+- [SiteSearch repository](https://github.com/algolia/sitesearch)


### PR DESCRIPTION
Regularize spelling and capitalization:

- Use sentence case for all headings and list items
- Use preferred spelling of product names
- Avoid `&` instead of `and` 
- Formatting (empty lines surrounding headings, lists, and code blocks)