### PR TITLE
fix(doc): wrong experience url

### DIFF
--- a/apps/docs/content/docs/getting-started/vanilla.mdx
+++ b/apps/docs/content/docs/getting-started/vanilla.mdx
@@ -13,7 +13,7 @@ Use our CDN bundle or customize to your needs with our [CodeSandbox](https://cod
 
 ### Usage
 
-We document how to use each experience in the [Experiences](/docs/experiences) section **under the VanillaJS tab**.
+We document how to use each experience in the [Experiences](/docs/experiences/search) section **under the VanillaJS tab**.
 
 Typical example for the `search` experience:
 


### PR DESCRIPTION
Small redirection issue I noticed when browsing the docs