### PR TITLE
feat: add openResultsInNewTab prop to search experiences

### DIFF
--- a/apps/docs/src/registry/experiences/search-askai/components/search-ai.tsx
+++ b/apps/docs/src/registry/experiences/search-askai/components/search-ai.tsx
@@ -83,6 +83,8 @@ export interface SearchWithAskAIConfig {
   insights?: boolean;
   /** Suggested Questions Enabled (optional, defaults to false) */
   suggestedQuestionsEnabled?: boolean;
+  /** Open hit URLs in a new tab (optional, defaults to true) */
+  openResultsInNewTab?: boolean;
 }
 
 interface SearchButtonProps extends React.ComponentProps<typeof Button> {}
@@ -1049,6 +1051,7 @@ interface HitsListProps {
   onHoverIndex?: (index: number) => void;
   hoverEnabled?: boolean;
   sendEvent?: (eventType: "click", hit: any, eventName: string) => void;
+  openResultsInNewTab?: boolean;
 }
 
 const HitsList = memo(function HitsList({
@@ -1060,6 +1063,7 @@ const HitsList = memo(function HitsList({
   onHoverIndex,
   hoverEnabled,
   sendEvent,
+  openResultsInNewTab = true,
 }: HitsListProps) {
   const [failedImages, setFailedImages] = useState<Record<string, boolean>>({});
   const mapping = useMemo(
@@ -1098,8 +1102,8 @@ const HitsList = memo(function HitsList({
           <a
             key={hit.objectID}
             href={url ?? "#"}
-            target={url ? "_blank" : undefined}
-            rel="noopener noreferrer"
+            target={openResultsInNewTab && url ? "_blank" : undefined}
+            rel={openResultsInNewTab && url ? "noopener noreferrer" : undefined}
             className={`my-1 p-4 rounded-lg bg-background gap-4 cursor-pointer no-underline text-foreground transition-all duration-150 block hover:bg-blue-50 hover:border-border hover:shadow-lg hover:-translate-y-px aria-selected:bg-blue-50 aria-selected:border-border aria-selected:shadow-lg aria-selected:-translate-y-px dark:hover:bg-slate-900 dark:aria-selected:bg-slate-900 animate-in fade-in-0 zoom-in-95 ${
               hasImage ? "flex flex-row items-center gap-4" : ""
             }`}
@@ -1540,6 +1544,7 @@ const ResultsPanel = memo(function ResultsPanel({
           onHoverIndex={onHoverIndex}
           hoverEnabled={hoverEnabled}
           sendEvent={sendEvent}
+          openResultsInNewTab={config.openResultsInNewTab}
         />
       </div>
     </>
@@ -1734,7 +1739,7 @@ function SearchModal({ onClose, config }: SearchModalProps) {
     activateSelection,
     hoverIndex,
     selectionOrigin,
-  } = useKeyboardNavigation(showChat, items, query);
+  } = useKeyboardNavigation(showChat, items, query, config.openResultsInNewTab ?? true);
 
   const handleActivateSelection = useCallback((): boolean => {
     // Send click event for keyboard navigation before activating

--- a/apps/docs/src/registry/experiences/search-askai/hooks/use-keyboard-navigation.ts
+++ b/apps/docs/src/registry/experiences/search-askai/hooks/use-keyboard-navigation.ts
@@ -11,8 +11,9 @@ interface UseKeyboardNavigationReturn {
 
 export function useKeyboardNavigation(
   showChat: boolean,
-  hits: any[],
+  hits: Array<Record<string, unknown>>,
   query: string,
+  openResultsInNewTab = true,
 ): UseKeyboardNavigationReturn {
   const [selectedIndex, setSelectedIndex] = useState<number>(0);
   const [selectionOrigin, setSelectionOrigin] = useState<
@@ -49,13 +50,18 @@ export function useKeyboardNavigation(
     }
     if (selectedIndex > 0) {
       const hit = hits[selectedIndex - 1];
-      if (hit?.url) {
-        window.open(hit.url, "_blank", "noopener,noreferrer");
+      const url = typeof hit?.url === "string" ? hit.url : undefined;
+      if (url) {
+        if (openResultsInNewTab) {
+          window.open(url, "_blank", "noopener,noreferrer");
+        } else {
+          window.location.assign(url);
+        }
         return true;
       }
     }
     return false;
-  }, [showChat, selectedIndex, hits]);
+  }, [showChat, selectedIndex, hits, openResultsInNewTab]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: expected
   useEffect(() => {

--- a/apps/docs/src/registry/experiences/search/components/search.tsx
+++ b/apps/docs/src/registry/experiences/search/components/search.tsx
@@ -43,6 +43,8 @@ export interface SearchConfig {
   searchParameters?: Record<string, unknown>;
   /** Enable Algolia Insights (optional, defaults to true) */
   insights?: boolean;
+  /** Open hit URLs in a new tab (optional, defaults to true) */
+  openResultsInNewTab?: boolean;
 }
 // =========================================================================
 // Attribute Mapping
@@ -278,6 +280,7 @@ interface HitsListProps {
   onHoverIndex?: (index: number) => void;
   hoverEnabled?: boolean;
   sendEvent?: (eventType: "click", hit: any, eventName: string) => void;
+  openResultsInNewTab?: boolean;
 }
 
 const HitsList = memo(function HitsList({
@@ -287,6 +290,7 @@ const HitsList = memo(function HitsList({
   onHoverIndex,
   hoverEnabled,
   sendEvent,
+  openResultsInNewTab = true,
 }: HitsListProps) {
   const [failedImages, setFailedImages] = useState<Record<string, boolean>>({});
   const mapping = useMemo(
@@ -317,8 +321,8 @@ const HitsList = memo(function HitsList({
           <a
             key={hit.objectID}
             href={url ?? "#"}
-            target={url ? "_blank" : undefined}
-            rel="noopener noreferrer"
+            target={openResultsInNewTab && url ? "_blank" : undefined}
+            rel={openResultsInNewTab && url ? "noopener noreferrer" : undefined}
             className="flex flex-row items-center gap-4 cursor-pointer text-decoration-none text-foreground bg-background rounded-sm p-4 aria-selected:bg-blue-50 dark:aria-selected:bg-slate-900 animate-in fade-in-0 zoom-in-95"
             role="option"
             aria-selected={isSel}
@@ -621,6 +625,7 @@ const ResultsPanel = memo(function ResultsPanel({
           onHoverIndex={onHoverIndex}
           hoverEnabled={hoverEnabled}
           sendEvent={sendEvent}
+          openResultsInNewTab={config.openResultsInNewTab}
         />
       </div>
     </>
@@ -647,7 +652,7 @@ export function SearchModal({ onClose, config }: SearchModalProps) {
     activateSelection,
     hoverIndex,
     selectionOrigin,
-  } = useKeyboardNavigation(items, query);
+  } = useKeyboardNavigation(items, query, config.openResultsInNewTab ?? true);
 
   const handleActivateSelection = useCallback((): boolean => {
     // Send click event for keyboard navigation before activating

--- a/apps/docs/src/registry/experiences/search/hooks/use-keyboard-navigation.ts
+++ b/apps/docs/src/registry/experiences/search/hooks/use-keyboard-navigation.ts
@@ -10,8 +10,9 @@ interface UseKeyboardNavigationReturn {
 }
 
 export function useKeyboardNavigation(
-  hits: any[],
+  hits: Array<Record<string, unknown>>,
   query: string,
+  openResultsInNewTab = true,
 ): UseKeyboardNavigationReturn {
   const [selectedIndex, setSelectedIndex] = useState<number>(0);
   const [selectionOrigin, setSelectionOrigin] = useState<
@@ -41,12 +42,17 @@ export function useKeyboardNavigation(
 
   const activateSelection = useCallback((): boolean => {
     const hit = hits[selectedIndex];
-    if (hit?.url) {
-      window.open(hit.url, "_blank", "noopener,noreferrer");
+    const url = typeof hit?.url === "string" ? hit.url : undefined;
+    if (url) {
+      if (openResultsInNewTab) {
+        window.open(url, "_blank", "noopener,noreferrer");
+      } else {
+        window.location.assign(url);
+      }
       return true;
     }
     return false;
-  }, [selectedIndex, hits]);
+  }, [selectedIndex, hits, openResultsInNewTab]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: expected
   useEffect(() => {

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@algolia/sitesearch",
   "private": false,
-  "version": "1.0.9",
+  "version": "1.0.10",
   "type": "module",
   "main": "dist/search.min.js",
   "types": "dist/index.d.ts",

--- a/packages/standalone/src/components/search-askai/hits-list.tsx
+++ b/packages/standalone/src/components/search-askai/hits-list.tsx
@@ -60,6 +60,7 @@ interface HitsListProps {
   onHoverIndex?: (index: number) => void;
   hoverEnabled?: boolean;
   sendEvent?: (eventType: "click", hit: SearchHit, eventName: string) => void;
+  openResultsInNewTab?: boolean;
 }
 
 export const HitsList = memo(function HitsList({
@@ -71,6 +72,7 @@ export const HitsList = memo(function HitsList({
   onHoverIndex,
   hoverEnabled,
   sendEvent,
+  openResultsInNewTab = true,
 }: HitsListProps) {
   const mapping: Required<Pick<HitsAttributesMapping, "primaryText">> &
     Partial<HitsAttributesMapping> = useMemo(
@@ -96,8 +98,8 @@ export const HitsList = memo(function HitsList({
           <a
             key={hit.objectID}
             href={hit.url}
-            target="_blank"
-            rel="noopener noreferrer"
+            target={openResultsInNewTab ? "_blank" : undefined}
+            rel={openResultsInNewTab ? "noopener noreferrer" : undefined}
             className="ss-infinite-hits-item ss-infinite-hits-anchor"
             role="option"
             aria-selected={isSel}

--- a/packages/standalone/src/components/search-askai/index.tsx
+++ b/packages/standalone/src/components/search-askai/index.tsx
@@ -53,6 +53,8 @@ export interface SearchWithAskAIConfig {
   searchParameters?: Record<string, unknown>;
   /** Suggested Questions Enabled (optional, defaults to false) */
   suggestedQuestionsEnabled?: boolean;
+  /** Open hit URLs in a new tab (optional, defaults to true) */
+  openResultsInNewTab?: boolean;
 }
 
 interface SearchBoxProps {
@@ -153,6 +155,7 @@ interface ResultsPanelProps {
   suggestedQuestions?: SuggestedQuestionHit[];
   onNewChat?: () => void;
   hasThreadDepthError?: boolean;
+  openResultsInNewTab?: boolean;
 }
 
 const ResultsPanel: FC<ResultsPanelProps> = memo(function ResultsPanel({
@@ -173,6 +176,7 @@ const ResultsPanel: FC<ResultsPanelProps> = memo(function ResultsPanel({
   suggestedQuestions,
   onNewChat,
   hasThreadDepthError,
+  openResultsInNewTab = true,
 }) {
   const { items } = useHits();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -270,6 +274,7 @@ const ResultsPanel: FC<ResultsPanelProps> = memo(function ResultsPanel({
           onHoverIndex={onHoverIndex}
           hoverEnabled={hoverEnabled}
           sendEvent={sendEvent}
+          openResultsInNewTab={openResultsInNewTab}
         />
       </div>
     </>
@@ -336,7 +341,7 @@ export function SearchModal({ onClose, config }: SearchModalProps) {
     activateSelection,
     hoverIndex,
     selectionOrigin,
-  } = useKeyboardNavigation(showChat, items, query);
+  } = useKeyboardNavigation(showChat, items, query, config.openResultsInNewTab ?? true);
 
   const handleActivateSelection = useCallback((): boolean => {
     // Send click event for keyboard navigation before activating
@@ -420,6 +425,7 @@ export function SearchModal({ onClose, config }: SearchModalProps) {
             suggestedQuestions={suggestedQuestions}
             onNewChat={handleNewChat}
             hasThreadDepthError={hasThreadDepthError}
+            openResultsInNewTab={config.openResultsInNewTab}
           />
         )}
         {noResults && query && !showChat && (

--- a/packages/standalone/src/components/search-askai/useKeyboardNavigation.ts
+++ b/packages/standalone/src/components/search-askai/useKeyboardNavigation.ts
@@ -11,8 +11,9 @@ interface UseKeyboardNavigationReturn {
 
 export function useKeyboardNavigation(
   showChat: boolean,
-  hits: any[],
+  hits: Array<Record<string, unknown>>,
   query: string,
+  openResultsInNewTab = true,
 ): UseKeyboardNavigationReturn {
   const [selectedIndex, setSelectedIndex] = useState<number>(0);
   const [selectionOrigin, setSelectionOrigin] = useState<
@@ -49,13 +50,18 @@ export function useKeyboardNavigation(
     }
     if (selectedIndex > 0) {
       const hit = hits[selectedIndex - 1];
-      if (hit?.url) {
-        window.open(hit.url, "_blank", "noopener,noreferrer");
+      const url = typeof hit?.url === "string" ? hit.url : undefined;
+      if (url) {
+        if (openResultsInNewTab) {
+          window.open(url, "_blank", "noopener,noreferrer");
+        } else {
+          window.location.assign(url);
+        }
         return true;
       }
     }
     return false;
-  }, [showChat, selectedIndex, hits]);
+  }, [showChat, selectedIndex, hits, openResultsInNewTab]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: expected
   useEffect(() => {

--- a/packages/standalone/src/components/search/hits-list.tsx
+++ b/packages/standalone/src/components/search/hits-list.tsx
@@ -16,6 +16,7 @@ interface HitsListProps {
   onHoverIndex?: (index: number) => void;
   hoverEnabled?: boolean;
   sendEvent?: (eventType: "click", hit: SearchHit, eventName: string) => void;
+  openResultsInNewTab?: boolean;
 }
 
 export const HitsList = memo(function HitsList({
@@ -25,6 +26,7 @@ export const HitsList = memo(function HitsList({
   onHoverIndex,
   hoverEnabled,
   sendEvent,
+  openResultsInNewTab = true,
 }: HitsListProps) {
   const [failedImages, setFailedImages] = useState<Record<string, boolean>>({});
   const mapping = useMemo(
@@ -55,8 +57,8 @@ export const HitsList = memo(function HitsList({
           <a
             key={hit.objectID}
             href={url ?? "#"}
-            target={url ? "_blank" : undefined}
-            rel="noopener noreferrer"
+            target={openResultsInNewTab && url ? "_blank" : undefined}
+            rel={openResultsInNewTab && url ? "noopener noreferrer" : undefined}
             className="ss-infinite-hits-item ss-infinite-hits-anchor"
             role="option"
             aria-selected={isSel}

--- a/packages/standalone/src/components/search/index.tsx
+++ b/packages/standalone/src/components/search/index.tsx
@@ -42,6 +42,8 @@ export interface SearchConfig {
   insights?: boolean;
   /** Additional Algolia search parameters (optional) - e.g., analytics, filters, distinct, etc. */
   searchParameters?: Record<string, unknown>;
+  /** Open hit URLs in a new tab (optional, defaults to true) */
+  openResultsInNewTab?: boolean;
 }
 
 interface SearchBoxProps {
@@ -104,6 +106,7 @@ interface ResultsPanelProps {
   onHoverIndex?: (index: number) => void;
   scrollOnSelectionChange?: boolean;
   sendEvent?: (eventType: "click", hit: any, eventName: string) => void;
+  openResultsInNewTab?: boolean;
 }
 
 const ResultsPanel: FC<ResultsPanelProps> = memo(function ResultsPanel({
@@ -113,6 +116,7 @@ const ResultsPanel: FC<ResultsPanelProps> = memo(function ResultsPanel({
   onHoverIndex,
   scrollOnSelectionChange = true,
   sendEvent,
+  openResultsInNewTab = true,
 }) {
   const { items } = useHits();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -163,6 +167,7 @@ const ResultsPanel: FC<ResultsPanelProps> = memo(function ResultsPanel({
           onHoverIndex={onHoverIndex}
           hoverEnabled={hoverEnabled}
           sendEvent={sendEvent}
+          openResultsInNewTab={openResultsInNewTab}
         />
       </div>
     </>
@@ -200,7 +205,7 @@ export function SearchModal({ onClose, config }: SearchModalProps) {
     activateSelection,
     hoverIndex,
     selectionOrigin,
-  } = useKeyboardNavigation(items, query);
+  } = useKeyboardNavigation(items, query, config.openResultsInNewTab ?? true);
 
   const handleActivateSelection = useCallback((): boolean => {
     // Send click event for keyboard navigation before activating
@@ -247,6 +252,7 @@ export function SearchModal({ onClose, config }: SearchModalProps) {
             onHoverIndex={hoverIndex}
             scrollOnSelectionChange={selectionOrigin !== "pointer"}
             sendEvent={sendEvent}
+            openResultsInNewTab={config.openResultsInNewTab}
           />
         )}
         {noResults && query && (

--- a/packages/standalone/src/components/search/useKeyboardNavigation.ts
+++ b/packages/standalone/src/components/search/useKeyboardNavigation.ts
@@ -10,8 +10,9 @@ interface UseKeyboardNavigationReturn {
 }
 
 export function useKeyboardNavigation(
-  hits: any[],
+  hits: Array<Record<string, unknown>>,
   query: string,
+  openResultsInNewTab = true,
 ): UseKeyboardNavigationReturn {
   const [selectedIndex, setSelectedIndex] = useState<number>(0);
   const [selectionOrigin, setSelectionOrigin] = useState<
@@ -41,12 +42,17 @@ export function useKeyboardNavigation(
 
   const activateSelection = useCallback((): boolean => {
     const hit = hits[selectedIndex];
-    if (hit?.url) {
-      window.open(hit.url, "_blank", "noopener,noreferrer");
+    const url = typeof hit?.url === "string" ? hit.url : undefined;
+    if (url) {
+      if (openResultsInNewTab) {
+        window.open(url, "_blank", "noopener,noreferrer");
+      } else {
+        window.location.assign(url);
+      }
       return true;
     }
     return false;
-  }, [selectedIndex, hits]);
+  }, [selectedIndex, hits, openResultsInNewTab]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: expected
   useEffect(() => {


### PR DESCRIPTION
**TLDR:** Add optional `openResultsInNewTab` prop to control whether search result links open in new tabs or same tab, with consistent behavior for both click and keyboard navigation.

**Description:**
- Add `openResultsInNewTab` prop (defaults to `true`) to `SearchConfig` and `SearchWithAskAIConfig` interfaces in both apps/docs and packages/standalone
- Update `HitsList` components to conditionally set `target="_blank"` and `rel="noopener noreferrer"` based on the prop
- Update `useKeyboardNavigation` hooks to respect the prop when opening hits via Enter key (uses `window.open` vs `window.location.assign`)
- Prop only affects search results, not AI chat markdown links in search-askai experiences