### PR TITLE
feat: add transformItems option SearchConfig

### DIFF
--- a/apps/docs/src/registry/experiences/search-askai/components/search-ai.tsx
+++ b/apps/docs/src/registry/experiences/search-askai/components/search-ai.tsx
@@ -85,6 +85,8 @@ export interface SearchWithAskAIConfig {
   suggestedQuestionsEnabled?: boolean;
   /** Open hit URLs in a new tab (optional, defaults to true) */
   openResultsInNewTab?: boolean;
+  /** Transform items before rendering (optional) - useful for proxying images or modifying hit data */
+  transformItems?: (items: any[]) => any[];
 }
 
 interface SearchButtonProps extends React.ComponentProps<typeof Button> {}
@@ -1444,7 +1446,9 @@ const ResultsPanel = memo(function ResultsPanel({
   suggestedQuestions,
   onNewChat,
 }: ResultsPanelProps) {
-  const { items } = useHits();
+  const { items } = useHits(
+    config.transformItems ? { transformItems: config.transformItems } : {}
+  );
   const containerRef = useRef<HTMLDivElement>(null);
   const [hoverEnabled, setHoverEnabled] = useState(false);
 
@@ -1684,7 +1688,9 @@ function SearchModal({ onClose, config }: SearchModalProps) {
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   const results = useInstantSearch();
-  const { items, sendEvent } = useHits();
+  const { items, sendEvent } = useHits(
+    config.transformItems ? { transformItems: config.transformItems } : {}
+  );
   const { showChat, setShowChat, handleShowChat } = useSearchState();
 
   // Track the message count when a thread depth error occurred

--- a/apps/docs/src/registry/experiences/search/components/search.tsx
+++ b/apps/docs/src/registry/experiences/search/components/search.tsx
@@ -45,6 +45,8 @@ export interface SearchConfig {
   insights?: boolean;
   /** Open hit URLs in a new tab (optional, defaults to true) */
   openResultsInNewTab?: boolean;
+  /** Transform items before rendering (optional) - useful for proxying images or modifying hit data */
+  transformItems?: (items: any[]) => any[];
 }
 // =========================================================================
 // Attribute Mapping
@@ -573,7 +575,9 @@ const ResultsPanel = memo(function ResultsPanel({
   scrollOnSelectionChange = true,
   sendEvent,
 }: ResultsPanelProps) {
-  const { items } = useHits();
+  const { items } = useHits(
+    config.transformItems ? { transformItems: config.transformItems } : {}
+  );
   const containerRef = useRef<HTMLDivElement>(null);
   const [hoverEnabled, setHoverEnabled] = useState(false);
 
@@ -642,7 +646,9 @@ export function SearchModal({ onClose, config }: SearchModalProps) {
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   const results = useInstantSearch();
-  const { items, sendEvent } = useHits();
+  const { items, sendEvent } = useHits(
+    config.transformItems ? { transformItems: config.transformItems } : {}
+  );
 
   const noResults = results.results?.nbHits === 0;
   const {

--- a/packages/standalone/README.md
+++ b/packages/standalone/README.md
@@ -41,7 +41,13 @@ Add CSS + JS from unpkg, then initialize.
       tertiaryText: "itunesAuthor", // optional tertiary text
       url: "url" // optional url attribute
       image: 'image', // optional URL attribute
-    }
+    },
+    // Optional: Transform items before rendering (e.g., proxy images)
+    transformItems: (items) => 
+      items.map(item => ({
+        ...item,
+        image: item.image ? `https://your-proxy.com/${item.image}` : item.image
+      }))
   });
 </script>
 ```
@@ -77,6 +83,13 @@ Key variables include:
 - `--search-results-max-height`
 
 Tip: The components auto-detect dark mode if `html.dark` is present or if the OS prefers dark, unless `darkMode` is explicitly set.
+
+## Transform Items
+
+The `transformItems` option allows you to modify search results before they are rendered. This is useful for:
+
+- **Proxying images** – Work around CORS issues or use a CDN
+- **Formatting data** – Transform dates, prices, or other fields
 
 ## Accessibility & Keyboard
 

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@algolia/sitesearch",
   "private": false,
-  "version": "1.0.10",
+  "version": "1.0.11",
   "type": "module",
   "main": "dist/search.min.js",
   "types": "dist/index.d.ts",

--- a/packages/standalone/src/components/search-askai/index.tsx
+++ b/packages/standalone/src/components/search-askai/index.tsx
@@ -55,6 +55,8 @@ export interface SearchWithAskAIConfig {
   suggestedQuestionsEnabled?: boolean;
   /** Open hit URLs in a new tab (optional, defaults to true) */
   openResultsInNewTab?: boolean;
+  /** Transform items before rendering (optional) - useful for proxying images or modifying hit data */
+  transformItems?: (items: any[]) => any[];
 }
 
 interface SearchBoxProps {
@@ -178,7 +180,9 @@ const ResultsPanel: FC<ResultsPanelProps> = memo(function ResultsPanel({
   hasThreadDepthError,
   openResultsInNewTab = true,
 }) {
-  const { items } = useHits();
+  const { items } = useHits(
+    config.transformItems ? { transformItems: config.transformItems } : {}
+  );
   const containerRef = useRef<HTMLDivElement>(null);
   const [hoverEnabled, setHoverEnabled] = useState(false);
 
@@ -291,7 +295,9 @@ export function SearchModal({ onClose, config }: SearchModalProps) {
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   const results = useInstantSearch();
-  const { items, sendEvent } = useHits();
+  const { items, sendEvent } = useHits(
+    config.transformItems ? { transformItems: config.transformItems } : {}
+  );
   const { showChat, setShowChat, handleShowChat } = useSearchState();
 
   // Focus input when modal opens

--- a/packages/standalone/src/components/search/index.tsx
+++ b/packages/standalone/src/components/search/index.tsx
@@ -120,7 +120,9 @@ const ResultsPanel: FC<ResultsPanelProps> = memo(function ResultsPanel({
   sendEvent,
   openResultsInNewTab = true,
 }) {
-  const { items } = useHits();
+  const { items } = useHits(
+    config.transformItems ? { transformItems: config.transformItems } : {}
+  );
   const containerRef = useRef<HTMLDivElement>(null);
   const [hoverEnabled, setHoverEnabled] = useState(false);
 

--- a/packages/standalone/src/components/search/index.tsx
+++ b/packages/standalone/src/components/search/index.tsx
@@ -44,6 +44,8 @@ export interface SearchConfig {
   searchParameters?: Record<string, unknown>;
   /** Open hit URLs in a new tab (optional, defaults to true) */
   openResultsInNewTab?: boolean;
+  /** Transform items before rendering (optional) - useful for proxying images or modifying hit data */
+  transformItems?: (items: any[]) => any[];
 }
 
 interface SearchBoxProps {
@@ -184,7 +186,9 @@ export function SearchModal({ onClose, config }: SearchModalProps) {
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   const results = useInstantSearch();
-  const { items, sendEvent } = useHits();
+  const { items, sendEvent } = useHits(
+    config.transformItems ? { transformItems: config.transformItems } : {}
+  );
 
   // Focus input when modal opens
   useEffect(() => {


### PR DESCRIPTION
## Issue to solve 
Image sources are not part of the CSP
<img width="728" height="420" alt="image" src="https://github.com/user-attachments/assets/0e1b5bdf-1950-4d46-a58c-fedc0c96abfe" />

## Changes
- Add transformItems parameter to SearchConfig and SearchWithAskAIConfig
- Pass transformItems to useHits hook following Algolia docs
- Add documentation and examples

## Previews 
<img width="1194" height="529" alt="image" src="https://github.com/user-attachments/assets/4d88927a-3e90-4adb-b250-e901477bc4c8" />
