### PR TITLE
chore: force biome formatting

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "instant-site-search",
       "devDependencies": {
         "@biomejs/biome": "2.0.0",
+        "simple-git-hooks": "^2.13.1",
       },
     },
     "apps/docs": {
@@ -1644,6 +1645,8 @@
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "simple-git-hooks": ["simple-git-hooks@2.13.1", "", { "bin": { "simple-git-hooks": "cli.js" } }, "sha512-WszCLXwT4h2k1ufIXAgsbiTOazqqevFCIncOuUBZJ91DdvWcC5+OFkluWRQPrcuSYd8fjq+o2y1QfWqYMoAToQ=="],
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,13 @@
     "build:docs": "bun --filter docs build",
     "bundle": "bun --filter @algolia/sitesearch build",
     "dev:vanilla": "bun --filter @algolia/sitesearch dev & bun --filter vanilla serve",
-    "build:vanilla": "bun --filter @algolia/sitesearch build"
+    "build:vanilla": "bun --filter @algolia/sitesearch build",
+    "prepare": "simple-git-hooks",
+    "format": "biome format --write .",
+    "lint": "biome lint .",
+    "check": "biome check .",
+    "fix": "biome check --write .",
+    "fix:staged": "biome check --write --staged --no-errors-on-unmatched && git update-index --again"
   },
   "keywords": [],
   "author": "",
@@ -19,7 +25,11 @@
   ],
   "packageManager": "bun@1.3.0",
   "devDependencies": {
-    "@biomejs/biome": "2.0.0"
+    "@biomejs/biome": "2.0.0",
+    "simple-git-hooks": "^2.13.1"
+  },
+  "simple-git-hooks": {
+    "pre-commit": "bun run fix:staged"
   },
   "engines": {
     "node": ">=22.0.0",


### PR DESCRIPTION
- Add `simple-git-hooks` to allow for pre-commit actions (right now, only `fix:staged` script)
- Add other scripts to help with formatting/linting
- Uses biome pre-existing configuration