### PR TITLE
feat(agentStudio): surface thread depth error

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,0 +1,5 @@
+---
+# Dev-only script: builds paths from import.meta.url + fixed layout; Semgrep/Codacy
+# flags non-literal fs paths as false positives.
+exclude_paths:
+  - "apps/vanilla/scripts/link-sitesearch.mjs"

--- a/apps/docs/src/registry/experiences/search-askai/components/search-ai.tsx
+++ b/apps/docs/src/registry/experiences/search-askai/components/search-ai.tsx
@@ -745,13 +745,13 @@ const ChatWidget = memo(function ChatWidget({
                 </div>
               ) : null}
             </div>
-            <p className="text-sm m-0 text-muted-foreground">
-              Answers are generated using AI and may make mistakes.
+            <p className="text-sm m-0 text-left text-muted-foreground self-stretch">
+              Answers are generated with AI which can make mistakes.
             </p>
           </>
         ) : (
-          <p className="text-sm m-0 text-muted-foreground">
-            Answers are generated using AI and may make mistakes.
+          <p className="text-sm m-0 text-left text-muted-foreground self-stretch">
+            Answers are generated with AI which can make mistakes.
           </p>
         )}
         {/* errors */}
@@ -1251,14 +1251,19 @@ const SearchInput = memo(function SearchInput(props: SearchInputProps) {
   const placeholder = props.isGenerating
     ? "Answering..."
     : props.showChat
-      ? "Ask AI anything about Algolia"
+      ? "Ask AI anything"
       : props.placeholder;
 
   const currentValue = props.showChat ? chatInput : query || "";
 
   return (
     <search
-      className="flex flex-row items-center bg-background border-b border-border rounded-t-lg p-2"
+      className={cn(
+        "flex flex-row items-center bg-background",
+        props.showChat
+          ? "mx-4 mt-3 mb-2 gap-1.5 rounded-lg border border-blue-600 py-1.5 pl-2 pr-1.5 dark:border-blue-500"
+          : "border-b border-border rounded-t-lg p-2",
+      )}
       onSubmit={(event) => {
         event.preventDefault();
         event.stopPropagation();
@@ -1279,7 +1284,10 @@ const SearchInput = memo(function SearchInput(props: SearchInputProps) {
       />
       <input
         ref={props.inputRef}
-        className="peer w-full outline-none bg-transparent border-none text-foreground text-xl font-light placeholder:text-muted-foreground disabled:opacity-50 disabled:cursor-not-allowed"
+        className={cn(
+          "peer w-full border-none bg-transparent font-light text-foreground outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+          props.showChat ? "py-0.5 text-xl leading-snug" : "text-xl",
+        )}
         autoComplete="off"
         autoCorrect="off"
         autoCapitalize="off"
@@ -1705,14 +1713,21 @@ function SearchModal({ onClose, config }: SearchModalProps) {
   const [threadDepthErrorAtMessageCount, setThreadDepthErrorAtMessageCount] =
     useState<number | null>(null);
 
-  const { messages, setMessages, error, isGenerating, sendMessage, status } =
-    useAskai({
-      applicationId: config.applicationId,
-      apiKey: config.apiKey,
-      indexName: config.indexName,
-      assistantId: config.assistantId,
-      agentStudio: config.agentStudio,
-    });
+  const {
+    messages,
+    error,
+    isGenerating,
+    sendMessage,
+    startNewConversation,
+    status,
+    hasThreadDepthError,
+  } = useAskai({
+    applicationId: config.applicationId,
+    apiKey: config.apiKey,
+    indexName: config.indexName,
+    assistantId: config.assistantId,
+    agentStudio: config.agentStudio,
+  });
 
   // Monitor for thread depth errors (AI-217)
   useEffect(() => {
@@ -1782,15 +1797,25 @@ function SearchModal({ onClose, config }: SearchModalProps) {
   const showResultsPanel = (!noResults && !!query) || showChat;
 
   const handleNewChat = useCallback(() => {
-    // Clear messages to start a fresh conversation
-    setMessages([]);
+    startNewConversation();
     setThreadDepthErrorAtMessageCount(null);
     setShowChat(true);
     refine("");
     if (inputRef.current) {
       inputRef.current.focus();
     }
-  }, [setMessages, setShowChat, refine]);
+  }, [startNewConversation, setShowChat, refine]);
+
+  const handleSetShowChat = useCallback(
+    (v: boolean) => {
+      if (!v && hasThreadDepthError) {
+        startNewConversation();
+        setThreadDepthErrorAtMessageCount(null);
+      }
+      setShowChat(v);
+    },
+    [setShowChat, hasThreadDepthError, startNewConversation],
+  );
 
   return (
     <>
@@ -1805,7 +1830,7 @@ function SearchModal({ onClose, config }: SearchModalProps) {
           refine={refine}
           showChat={showChat}
           isGenerating={isGenerating}
-          setShowChat={setShowChat}
+          setShowChat={handleSetShowChat}
           onClose={onClose}
           onArrowDown={moveDown}
           onArrowUp={moveUp}
@@ -1824,9 +1849,7 @@ function SearchModal({ onClose, config }: SearchModalProps) {
           <ResultsPanel
             showChat={showChat}
             inputRef={inputRef}
-            setShowChat={(v) => {
-              setShowChat(v);
-            }}
+            setShowChat={handleSetShowChat}
             query={query}
             selectedIndex={selectedIndex}
             refine={refine}

--- a/apps/docs/src/registry/experiences/search-askai/components/search-ai.tsx
+++ b/apps/docs/src/registry/experiences/search-askai/components/search-ai.tsx
@@ -47,6 +47,7 @@ import {
   isThreadDepthError,
   postAgentStudioFeedback,
   postFeedback,
+  threadDepthErrorDetail,
   useAskai,
 } from "@/registry/experiences/search-askai/hooks/use-askai";
 
@@ -562,19 +563,28 @@ const MemoizedMarkdown = memo(function MemoizedMarkdown({
 
 interface ThreadDepthErrorBannerProps {
   onNewChat: () => void;
+  detailMessage?: string;
 }
 
-const ThreadDepthErrorBanner = ({ onNewChat }: ThreadDepthErrorBannerProps) => (
+const ThreadDepthErrorBanner = ({
+  onNewChat,
+  detailMessage,
+}: ThreadDepthErrorBannerProps) => (
   <div className="text-gray-900 text-sm leading-normal">
-    This conversation is now closed to keep responses accurate.{" "}
-    <button
-      type="button"
-      className="text-blue-600 underline font-normal cursor-pointer bg-transparent border-none p-0 hover:text-blue-800 focus:outline-2 focus:outline-blue-600 focus:outline-offset-2 focus:rounded-sm"
-      onClick={onNewChat}
-    >
-      Start a new conversation
-    </button>{" "}
-    to continue.
+    {detailMessage ? (
+      <p className="m-0 mb-2 font-semibold text-foreground">{detailMessage}</p>
+    ) : null}
+    <p className="m-0">
+      This conversation is now closed to keep responses accurate.{" "}
+      <button
+        type="button"
+        className="text-blue-600 underline font-normal cursor-pointer bg-transparent border-none p-0 hover:text-blue-800 focus:outline-2 focus:outline-blue-600 focus:outline-offset-2 focus:rounded-sm"
+        onClick={onNewChat}
+      >
+        Start a new conversation
+      </button>{" "}
+      to continue.
+    </p>
   </div>
 );
 
@@ -663,22 +673,8 @@ const ChatWidget = memo(function ChatWidget({
   // Group messages into exchanges (user + assistant pairs)
   const exchanges = useMemo(() => {
     const grouped: Exchange[] = [];
-    let skipLastUserMessage = false;
-
-    // If there's a thread depth error, don't show the last user message
-    if (isThreadDepthError(error) && messages.length > 0) {
-      const lastMessage = messages[messages.length - 1];
-      if (lastMessage.role === "user") {
-        skipLastUserMessage = true;
-      }
-    }
 
     for (let i = 0; i < messages.length; i++) {
-      // Skip the last user message if it caused a thread depth error
-      if (skipLastUserMessage && i === messages.length - 1) {
-        continue;
-      }
-
       const current = messages[i];
       if (current.role === "user") {
         const userMessage = current as Message;
@@ -701,7 +697,7 @@ const ChatWidget = memo(function ChatWidget({
       }
     }
     return grouped;
-  }, [messages, error]);
+  }, [messages]);
 
   // Cleanup any pending reset timers on unmount
   useEffect(() => {
@@ -758,7 +754,10 @@ const ChatWidget = memo(function ChatWidget({
         {error && (
           <div className="border border-red-300 bg-red-100 text-red-900 px-4 py-3 rounded-lg">
             {isThreadDepthError(error) && onNewChat ? (
-              <ThreadDepthErrorBanner onNewChat={onNewChat} />
+              <ThreadDepthErrorBanner
+                onNewChat={onNewChat}
+                detailMessage={threadDepthErrorDetail(error)}
+              />
             ) : (
               error.message
             )}

--- a/apps/docs/src/registry/experiences/search-askai/hooks/use-askai.ts
+++ b/apps/docs/src/registry/experiences/search-askai/hooks/use-askai.ts
@@ -31,7 +31,55 @@ export function isThreadDepthError(error?: Error | null): boolean {
 
   // Check message content for AI-217 or thread depth references
   const message = error.message?.toLowerCase() || "";
-  return message.includes("ai-217") || message.includes("thread depth");
+  if (message.includes("ai-217") || message.includes("thread depth")) {
+    return true;
+  }
+  try {
+    const parsed = JSON.parse(error.message) as {
+      code?: string;
+      message?: string;
+    };
+    if (
+      typeof parsed.code === "string" &&
+      parsed.code.toUpperCase() === "AI-217"
+    ) {
+      return true;
+    }
+    const nested = (parsed.message ?? "").toLowerCase();
+    return nested.includes("ai-217") || nested.includes("thread depth");
+  } catch {
+    return false;
+  }
+}
+
+function threadDepthRawMessage(error: unknown): string {
+  if (!error) return "";
+  if (error instanceof Error) return (error.message ?? "").trim();
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof (error as { message: unknown }).message === "string"
+  ) {
+    return (error as { message: string }).message.trim();
+  }
+  return "";
+}
+
+/** Plain or JSON `{"message":"…"}` body from the API for thread-depth errors. */
+export function threadDepthErrorDetail(error?: unknown): string | undefined {
+  if (!isThreadDepthError(error as Error | null)) return undefined;
+  const raw = threadDepthRawMessage(error);
+  if (!raw) return undefined;
+  try {
+    const parsed = JSON.parse(raw) as { message?: string };
+    if (typeof parsed.message === "string" && parsed.message.trim()) {
+      return parsed.message.trim();
+    }
+  } catch {
+    // not JSON
+  }
+  return raw;
 }
 
 const BASE_ASKAI_URL = "https://askai.algolia.com";

--- a/apps/docs/src/registry/experiences/search-askai/hooks/use-askai.ts
+++ b/apps/docs/src/registry/experiences/search-askai/hooks/use-askai.ts
@@ -1,9 +1,10 @@
 import { useChat } from "@ai-sdk/react";
 import {
   DefaultChatTransport,
+  generateId,
   lastAssistantMessageIsCompleteWithToolCalls,
 } from "ai";
-import { useMemo } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 
 export interface AskAIConfig {
   applicationId: string;
@@ -50,6 +51,8 @@ export function useAskai(config: AskAIConfig) {
     throw new Error("config is required for useAskai");
   }
 
+  const [chatId, setChatId] = useState(() => generateId());
+
   const transport = useMemo(() => {
     return new DefaultChatTransport({
       api: getChatApiUrl(config),
@@ -81,9 +84,19 @@ export function useAskai(config: AskAIConfig) {
   ]);
 
   const chat = useChat({
+    id: chatId,
     transport,
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
   });
+
+  const chatRef = useRef(chat);
+  chatRef.current = chat;
+
+  const startNewConversation = useCallback(() => {
+    chatRef.current.stop();
+    chatRef.current.clearError();
+    setChatId(generateId());
+  }, []);
 
   const isGenerating =
     chat.status === "submitted" || chat.status === "streaming";
@@ -97,6 +110,7 @@ export function useAskai(config: AskAIConfig) {
 
   return {
     ...chat,
+    startNewConversation,
     isGenerating,
     hasThreadDepthError,
   };

--- a/apps/docs/src/registry/experiences/sidepanel-askai/components/sidepanel-askai.tsx
+++ b/apps/docs/src/registry/experiences/sidepanel-askai/components/sidepanel-askai.tsx
@@ -43,6 +43,7 @@ import {
   isThreadDepthError,
   postAgentStudioFeedback,
   postFeedback,
+  threadDepthErrorDetail,
   useAskai,
 } from "@/registry/experiences/sidepanel-askai/hooks/use-askai";
 
@@ -517,19 +518,28 @@ const RelatedSources = memo(function RelatedSources({
 
 interface ThreadDepthErrorBannerProps {
   onNewChat: () => void;
+  detailMessage?: string;
 }
 
-const ThreadDepthErrorBanner = ({ onNewChat }: ThreadDepthErrorBannerProps) => (
+const ThreadDepthErrorBanner = ({
+  onNewChat,
+  detailMessage,
+}: ThreadDepthErrorBannerProps) => (
   <div className="text-gray-900 text-sm leading-normal">
-    This conversation is now closed to keep responses accurate.{" "}
-    <button
-      type="button"
-      className="text-blue-600 underline font-normal cursor-pointer bg-transparent border-none p-0 hover:text-blue-800 focus:outline-2 focus:outline-blue-600 focus:outline-offset-2 focus:rounded-sm"
-      onClick={onNewChat}
-    >
-      Start a new conversation
-    </button>{" "}
-    to continue.
+    {detailMessage ? (
+      <p className="m-0 mb-2 font-semibold text-foreground">{detailMessage}</p>
+    ) : null}
+    <p className="m-0">
+      This conversation is now closed to keep responses accurate.{" "}
+      <button
+        type="button"
+        className="text-blue-600 underline font-normal cursor-pointer bg-transparent border-none p-0 hover:text-blue-800 focus:outline-2 focus:outline-blue-600 focus:outline-offset-2 focus:rounded-sm"
+        onClick={onNewChat}
+      >
+        Start a new conversation
+      </button>{" "}
+      to continue.
+    </p>
   </div>
 );
 
@@ -693,7 +703,10 @@ const ChatWidget = memo(function ChatWidget({
         {error && (
           <div className="border border-red-300 bg-red-100 text-red-900 px-4 py-3 rounded-lg">
             {isThreadDepthError(error) && onNewChat ? (
-              <ThreadDepthErrorBanner onNewChat={onNewChat} />
+              <ThreadDepthErrorBanner
+                onNewChat={onNewChat}
+                detailMessage={threadDepthErrorDetail(error)}
+              />
             ) : (
               error.message
             )}

--- a/apps/docs/src/registry/experiences/sidepanel-askai/components/sidepanel-askai.tsx
+++ b/apps/docs/src/registry/experiences/sidepanel-askai/components/sidepanel-askai.tsx
@@ -17,7 +17,7 @@ import {
   Link2Icon,
   Maximize2,
   Minimize2,
-  SparklesIcon,
+  Sparkles,
   SquarePen,
   ThumbsDown,
   ThumbsUp,
@@ -1119,8 +1119,12 @@ const Sidepanel = memo(function Sidepanel({
       >
         {/* Header */}
         <div className="flex items-center justify-between px-4 py-2 border-b border-border">
-          <div className="flex items-center gap-2">
-            <SparklesIcon size={20} className="text-blue-600" />
+          <div className="flex items-center gap-2 min-w-0">
+            <Sparkles
+              className="h-[18px] w-[18px] shrink-0 text-blue-600 dark:text-blue-500"
+              strokeWidth={2}
+              aria-hidden
+            />
             <h2 className="text-sm font-semibold text-foreground">Ask AI</h2>
           </div>
           <div className="flex items-center gap-2">
@@ -1174,11 +1178,14 @@ const Sidepanel = memo(function Sidepanel({
           onNewChat={onOpenNewConversation}
         />
 
-        {/* Input Bar */}
-        <div className="border-t border-border p-4">
+        {/* Input Bar — match search-askai composer (primary border + rule above footer). */}
+        <div className="border-t border-border px-4 pb-4 pt-2">
           <form
             onSubmit={handleSubmit}
-            className="flex border-border border rounded-md gap-2 p-2 focus-within:ring-1 focus-within:ring-blue-600 focus-within:border-transparent transition-all"
+            className={cn(
+              "flex items-center gap-2 rounded-lg border border-blue-600 py-1.5 pl-2 pr-1.5 transition-all dark:border-blue-500",
+              "focus-within:ring-1 focus-within:ring-blue-600 focus-within:ring-offset-0 dark:focus-within:ring-blue-500",
+            )}
           >
             <textarea
               ref={inputRef}
@@ -1197,19 +1204,22 @@ const Sidepanel = memo(function Sidepanel({
               rows={1}
               placeholder={config.placeholder || "Ask AI anything"}
               disabled={isGenerating}
-              className="flex-1 pt-1 border-none outline-none bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-0 focus:border-transparent disabled:opacity-50 disabled:cursor-not-allowed resize-none overflow-y-hidden"
+              className="flex-1 border-none bg-background py-0.5 leading-tight text-foreground outline-none placeholder:text-muted-foreground focus:border-transparent focus:outline-none focus:ring-0 disabled:cursor-not-allowed disabled:opacity-50 resize-none overflow-y-hidden"
             />
             <Button
-              size="icon-sm"
               type="submit"
-              className="self-end"
+              variant="secondary"
+              size="icon"
+              className="h-10 w-10 shrink-0 text-muted-foreground hover:bg-muted/80 hover:text-foreground"
               disabled={!inputValue.trim() || isGenerating}
+              title="Send message"
+              aria-label="Send message"
             >
-              <ArrowUpIcon size={18} />
+              <ArrowUpIcon size={22} strokeWidth={2.25} />
             </Button>
           </form>
-          <div className="mt-2 flex items-center justify-center text-xs text-muted-foreground">
-            <p className="m-0 text-center">
+          <div className="mt-2 flex items-start justify-start text-xs text-muted-foreground">
+            <p className="m-0 w-full text-left">
               Answers are generated with AI which can make mistakes.
             </p>
           </div>
@@ -1245,13 +1255,14 @@ export default function SidepanelExperience(config: SidepanelAskAIConfig) {
     return client;
   }, [config.applicationId, config.apiKey]);
 
-  const { messages, setMessages, error, isGenerating, sendMessage } = useAskai({
-    applicationId: config.applicationId,
-    apiKey: config.apiKey,
-    indexName: config.indexName,
-    assistantId: config.assistantId,
-    agentStudio: config.agentStudio,
-  });
+  const { messages, startNewConversation, error, isGenerating, sendMessage } =
+    useAskai({
+      applicationId: config.applicationId,
+      apiKey: config.apiKey,
+      indexName: config.indexName,
+      assistantId: config.assistantId,
+      agentStudio: config.agentStudio,
+    });
 
   const suggestedQuestions = useSuggestedQuestions({
     searchClient,
@@ -1278,7 +1289,7 @@ export default function SidepanelExperience(config: SidepanelAskAIConfig) {
   const openSidepanel = () => setIsOpen(true);
   const closeSidepanel = () => setIsOpen(false);
   const openNewConversation = () => {
-    setMessages?.([]);
+    startNewConversation();
     setIsOpen(true);
   };
   const buttonProps = {

--- a/apps/docs/src/registry/experiences/sidepanel-askai/hooks/use-askai.ts
+++ b/apps/docs/src/registry/experiences/sidepanel-askai/hooks/use-askai.ts
@@ -1,9 +1,10 @@
 import { useChat } from "@ai-sdk/react";
 import {
   DefaultChatTransport,
+  generateId,
   lastAssistantMessageIsCompleteWithToolCalls,
 } from "ai";
-import { useMemo } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 
 export interface AskAIConfig {
   applicationId: string;
@@ -46,6 +47,8 @@ export function useAskai(config: AskAIConfig) {
     throw new Error("config is required for useAskai");
   }
 
+  const [chatId, setChatId] = useState(() => generateId());
+
   const transport = useMemo(() => {
     return new DefaultChatTransport({
       api: getChatApiUrl(config),
@@ -77,9 +80,19 @@ export function useAskai(config: AskAIConfig) {
   ]);
 
   const chat = useChat({
+    id: chatId,
     transport,
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
   });
+
+  const chatRef = useRef(chat);
+  chatRef.current = chat;
+
+  const startNewConversation = useCallback(() => {
+    chatRef.current.stop();
+    chatRef.current.clearError();
+    setChatId(generateId());
+  }, []);
 
   const isGenerating =
     chat.status === "submitted" || chat.status === "streaming";
@@ -93,6 +106,7 @@ export function useAskai(config: AskAIConfig) {
 
   return {
     ...chat,
+    startNewConversation,
     isGenerating,
     hasThreadDepthError,
   };

--- a/apps/docs/src/registry/experiences/sidepanel-askai/hooks/use-askai.ts
+++ b/apps/docs/src/registry/experiences/sidepanel-askai/hooks/use-askai.ts
@@ -27,7 +27,55 @@ export function isThreadDepthError(error?: Error | null): boolean {
 
   // Check message content for AI-217 or thread depth references
   const message = error.message?.toLowerCase() || "";
-  return message.includes("ai-217") || message.includes("thread depth");
+  if (message.includes("ai-217") || message.includes("thread depth")) {
+    return true;
+  }
+  try {
+    const parsed = JSON.parse(error.message) as {
+      code?: string;
+      message?: string;
+    };
+    if (
+      typeof parsed.code === "string" &&
+      parsed.code.toUpperCase() === "AI-217"
+    ) {
+      return true;
+    }
+    const nested = (parsed.message ?? "").toLowerCase();
+    return nested.includes("ai-217") || nested.includes("thread depth");
+  } catch {
+    return false;
+  }
+}
+
+function threadDepthRawMessage(error: unknown): string {
+  if (!error) return "";
+  if (error instanceof Error) return (error.message ?? "").trim();
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof (error as { message: unknown }).message === "string"
+  ) {
+    return (error as { message: string }).message.trim();
+  }
+  return "";
+}
+
+/** Plain or JSON `{"message":"…"}` body from the API for thread-depth errors. */
+export function threadDepthErrorDetail(error?: unknown): string | undefined {
+  if (!isThreadDepthError(error as Error | null)) return undefined;
+  const raw = threadDepthRawMessage(error);
+  if (!raw) return undefined;
+  try {
+    const parsed = JSON.parse(raw) as { message?: string };
+    if (typeof parsed.message === "string" && parsed.message.trim()) {
+      return parsed.message.trim();
+    }
+  } catch {
+    // not JSON
+  }
+  return raw;
 }
 
 const BASE_ASKAI_URL = "https://askai.algolia.com";

--- a/apps/vanilla/index.html
+++ b/apps/vanilla/index.html
@@ -6,6 +6,7 @@
   <title>Algolia SiteSearch Vanilla Demo</title>
   <link rel="stylesheet" href="./node_modules/@algolia/sitesearch/dist/search.min.css" />
   <link rel="stylesheet" href="./node_modules/@algolia/sitesearch/dist/search-askai.min.css" />
+  <link rel="stylesheet" href="./node_modules/@algolia/sitesearch/dist/sidepanel-askai.min.css" />
   <link rel="stylesheet" href="./style.css" />
   </head>
   <body>
@@ -29,6 +30,21 @@
               <div id="searchAskAi"></div>
             </div>
           </div>
+          <div class="card">
+            <h2>Search + Ask AI (Agent Studio)</h2>
+            <div class="demo-container">
+              <div id="searchAskAiAgentStudio"></div>
+            </div>
+          </div>
+          <div class="card">
+            <h2>Sidepanel Ask AI (Agent Studio)</h2>
+            <p class="card-note">
+              Floating chat panel via <code>SiteSearchSidepanelAskAI</code> — same credentials as the Agent Studio card; <code>triggerPosition: &quot;inline&quot;</code> keeps the button inside this card.
+            </p>
+            <div class="demo-container demo-container-sidepanel">
+              <div id="sidepanelAskAi"></div>
+            </div>
+          </div>
         </div>
 
         <div class="right-col">
@@ -38,7 +54,11 @@
               <ol class="doc-steps">
                 <li>
                   <h3>Iterate on the components</h3>
-                  <p>Edit in <code>packages/standalone/src/components/search/*</code></p>
+                  <p>Edit in <code>packages/standalone/src/components/search/*</code>, <code>search-askai/*</code>, and <code>sidepanel-askai/*</code></p>
+                </li>
+                <li>
+                  <h3>Ask AI vs Agent Studio</h3>
+                  <p>The middle card uses default Ask AI. The third and fourth cards use <code>agentStudio: true</code> (Agent Studio API). The fourth card loads <code>sidepanel-askai.min.js</code> — use <code>triggerPosition: &quot;fixed&quot;</code> for a viewport-fixed button in production.</p>
                 </li>
                 <li>
                   <h3>View your changes here</h3>
@@ -95,7 +115,7 @@
       const aaApiKey = "94b6afdc316917b6e6cdf2763fa561df";
       const aaIndexName = "algolia_podcast_sample_dataset";
 
-      // Search + Ask AI experience
+      // Search + Ask AI experience (default Ask AI endpoints)
       if (window.SiteSearchAskAI) {
         window.SiteSearchAskAI.init({
           container: "#searchAskAi",
@@ -111,6 +131,41 @@
             url: "url",
             image: "imageUrl",
           },
+        });
+
+        // Search with Agent Studio completions
+        window.SiteSearchAskAI.init({
+          container: "#searchAskAiAgentStudio",
+          applicationId: "PMZUYBQDAK",
+          apiKey: "40aa23271f25347826db43222329fdfa",
+          assistantId: "ccdec697-e3fe-465b-a1c3-657e7bf18aef",
+          suggestedQuestionsEnabled: true,
+          indexName: "algolia_movie_sample_dataset",
+          agentStudio: true,
+          attributes: {
+            primaryText: "title",
+            secondaryText: "description",
+            tertiaryText: "itunesAuthor",
+            url: "url",
+            image: "imageUrl",
+          },
+        });
+      }
+    </script>
+
+    <script src="./node_modules/@algolia/sitesearch/dist/sidepanel-askai.min.js"></script>
+    <script>
+      if (window.SiteSearchSidepanelAskAI) {
+        window.SiteSearchSidepanelAskAI.init({
+          container: "#sidepanelAskAi",
+          applicationId: "PMZUYBQDAK",
+          apiKey: "40aa23271f25347826db43222329fdfa",
+          assistantId: "ccdec697-e3fe-465b-a1c3-657e7bf18aef",
+          indexName: "algolia_movie_sample_dataset",
+          agentStudio: true,
+          suggestedQuestionsEnabled: true,
+          triggerPosition: "inline",
+          buttonText: "Ask AI",
         });
       }
     </script>

--- a/apps/vanilla/package.json
+++ b/apps/vanilla/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
+    "link-sitesearch": "node scripts/link-sitesearch.mjs",
+    "postinstall": "node scripts/link-sitesearch.mjs",
+    "preserve": "node scripts/link-sitesearch.mjs",
     "serve": "bunx vite serve . --open"
   },
   "dependencies": {

--- a/apps/vanilla/scripts/link-sitesearch.mjs
+++ b/apps/vanilla/scripts/link-sitesearch.mjs
@@ -1,0 +1,47 @@
+/**
+ * Ensures apps/vanilla/node_modules/@algolia/sitesearch → packages/standalone.
+ * Bun/npm often hoist workspace deps to the repo root, so ./node_modules/... in index.html would 404.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/** `apps/vanilla` (parent of `scripts/`). */
+const appRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const repoRoot = path.resolve(appRoot, "..", "..");
+
+const standaloneDir = path.join(repoRoot, "packages", "standalone");
+const algoliaDir = path.join(appRoot, "node_modules", "@algolia");
+const symlinkPath = path.join(algoliaDir, "sitesearch");
+
+const resolvedApp = path.resolve(appRoot);
+const resolvedSymlink = path.resolve(symlinkPath);
+if (!resolvedSymlink.startsWith(resolvedApp + path.sep)) {
+  throw new Error("link-sitesearch: symlink path must stay under apps/vanilla");
+}
+
+if (!fs.existsSync(standaloneDir)) {
+  console.warn(
+    "[vanilla] link-sitesearch: packages/standalone not found; skipping symlink",
+  );
+  process.exit(0);
+}
+
+fs.mkdirSync(algoliaDir, { recursive: true });
+
+try {
+  fs.unlinkSync(symlinkPath);
+} catch {
+  /* absent */
+}
+
+// Symlink uses paths built only from this file’s location + fixed segments; guarded above.
+// nosemgrep: javascript.lang.security.audit.detect-non-literal-fs-filename
+if (process.platform === "win32") {
+  fs.symlinkSync(standaloneDir, symlinkPath, "junction");
+} else {
+  fs.symlinkSync(standaloneDir, symlinkPath);
+}
+console.log(
+  "[vanilla] linked @algolia/sitesearch → packages/standalone (workspace)",
+);

--- a/apps/vanilla/style.css
+++ b/apps/vanilla/style.css
@@ -102,6 +102,43 @@ body {
   color: #0f172a;
 }
 
+.card-note {
+  font-size: 13px;
+  color: #475569;
+  margin: -4px 0 12px;
+  line-height: 1.5;
+}
+
+/* Sidepanel demo: avoid flex centering shrinking the mount; fill width so inline trigger aligns to dashed area */
+.demo-container-sidepanel {
+  position: relative;
+  display: block;
+  min-height: 132px;
+  padding: 1rem;
+}
+
+.demo-container-sidepanel > #sidepanelAskAi {
+  display: block;
+  width: 100%;
+  min-height: 104px;
+  position: relative;
+}
+
+.card-note code {
+  background: #eef2ff;
+  color: #3730a3;
+  padding: 1px 4px;
+  border-radius: 4px;
+  font-family:
+    IBM Plex Mono,
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Consolas,
+    monospace;
+  font-size: 12px;
+}
+
 .card h3 {
   font-size: 18px;
   font-weight: 600;

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "instant-site-search",

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -32,16 +32,16 @@
     "react-dom": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
+    "@types/node": "^22.12.9",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.0",
     "globals": "^16.3.0",
+    "postcss": "^8.4.49",
+    "preact": "^10.24.3",
     "rolldown": "^1.0.0-beta.38",
     "rolldown-plugin-dts": "^0.16.8",
     "rollup-plugin-postcss": "^4.0.2",
-    "postcss": "^8.4.49",
-    "@types/node": "^22.12.9",
-    "typescript": "^5.7.2",
-    "preact": "^10.24.3"
+    "typescript": "^5.7.2"
   }
 }

--- a/packages/standalone/rolldown.config.js
+++ b/packages/standalone/rolldown.config.js
@@ -52,6 +52,23 @@ export default defineConfig([
     ...common,
   },
   {
+    input: "src/vanilla/sidepanel-askai.tsx",
+    output: {
+      dir: "dist",
+      entryFileNames: "sidepanel-askai.min.js",
+      format: "umd",
+      name: "SiteSearchSidepanelAskAI",
+      sourcemap: true,
+      minify: true,
+    },
+    plugins: [
+      postcss({
+        extract: "sidepanel-askai.min.css",
+      }),
+    ],
+    ...common,
+  },
+  {
     input: "src/index.ts",
     output: { dir: "dist", format: "es" },
     plugins: [dts()],

--- a/packages/standalone/src/components/search-askai/askai.ts
+++ b/packages/standalone/src/components/search-askai/askai.ts
@@ -12,8 +12,6 @@ export interface AskAIConfig {
   indexName: string;
   assistantId: string;
   agentStudio?: boolean;
-  /** Demo mode: Simulate thread depth error after N exchanges (for testing only) */
-  _demoThreadDepthLimit?: number;
 }
 
 const BASE_ASKAI_URL = "https://askai.algolia.com";
@@ -75,20 +73,22 @@ export function useAskai(config: AskAIConfig) {
   const isGenerating =
     chat.status === "submitted" || chat.status === "streaming";
 
-  // Check if there's a thread depth error (AI-217)
-  // Only show error if there are messages (conversation is active)
-  const hasThreadDepthError = useMemo(() => {
-    const isError =
-      chat.status === "error" && isThreadDepthError(chat.error as Error | null);
-    const hasMessages = chat.messages.length > 0;
-    // Clear error if conversation was reset (no messages)
-    return isError && hasMessages;
-  }, [chat.status, chat.error, chat.messages.length]);
+  const threadDepthError = useMemo(
+    () => chat.status === "error" && isThreadDepthError(chat.error),
+    [chat.status, chat.error],
+  );
+
+  /** Banner, input lock, etc. — only after at least one assistant reply (real thread). */
+  const showThreadDepthError = useMemo(
+    () => threadDepthError && chat.messages.some((m) => m.role === "assistant"),
+    [threadDepthError, chat.messages],
+  );
 
   return {
     ...chat,
     isGenerating,
-    hasThreadDepthError,
+    threadDepthError,
+    showThreadDepthError,
   };
 }
 

--- a/packages/standalone/src/components/search-askai/askai.ts
+++ b/packages/standalone/src/components/search-askai/askai.ts
@@ -1,9 +1,10 @@
 import { useChat } from "@ai-sdk/react";
 import {
   DefaultChatTransport,
+  generateId,
   lastAssistantMessageIsCompleteWithToolCalls,
 } from "ai";
-import { useMemo } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { isThreadDepthError } from "./error-utils";
 
 export interface AskAIConfig {
@@ -34,6 +35,8 @@ export function useAskai(config: AskAIConfig) {
   if (!config) {
     throw new Error("config is required for useAskai");
   }
+
+  const [chatId, setChatId] = useState(() => generateId());
 
   const transport = useMemo(() => {
     return new DefaultChatTransport({
@@ -66,9 +69,19 @@ export function useAskai(config: AskAIConfig) {
   ]);
 
   const chat = useChat({
+    id: chatId,
     transport,
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
   });
+
+  const chatRef = useRef(chat);
+  chatRef.current = chat;
+
+  const startNewConversation = useCallback(() => {
+    chatRef.current.stop();
+    chatRef.current.clearError();
+    setChatId(generateId());
+  }, []);
 
   const isGenerating =
     chat.status === "submitted" || chat.status === "streaming";
@@ -86,6 +99,7 @@ export function useAskai(config: AskAIConfig) {
 
   return {
     ...chat,
+    startNewConversation,
     isGenerating,
     threadDepthError,
     showThreadDepthError,

--- a/packages/standalone/src/components/search-askai/chat.tsx
+++ b/packages/standalone/src/components/search-askai/chat.tsx
@@ -5,7 +5,11 @@ import type { SearchHit } from "../types";
 
 import { postAgentStudioFeedback, postFeedback } from "./askai";
 
-import { isThreadDepthError, ThreadDepthErrorBanner } from "./error-utils";
+import {
+  filterMessagesForThreadDepthError,
+  isThreadDepthError,
+  ThreadDepthErrorBanner,
+} from "./error-utils";
 import {
   BrainIcon,
   CheckIcon,
@@ -44,9 +48,10 @@ interface ChatWidgetProps {
   /** When true, feedback is sent to Agent Studio instead of the AskAI backend. */
   agentStudio?: boolean;
   suggestedQuestions?: SuggestedQuestionHit[];
+  threadDepthError?: boolean;
+  showThreadDepthError?: boolean;
   onSuggestedQuestionClick?: (question: string) => void;
   onNewChat?: () => void;
-  hasThreadDepthError?: boolean;
 }
 
 export interface SearchIndexTool {
@@ -94,7 +99,8 @@ export const ChatWidget = memo(function ChatWidget({
   suggestedQuestions,
   onSuggestedQuestionClick,
   onNewChat,
-  hasThreadDepthError,
+  threadDepthError = false,
+  showThreadDepthError = false,
 }: ChatWidgetProps) {
   const { copyText } = useClipboard();
   const [copiedExchangeId, setCopiedExchangeId] = useState<string | null>(null);
@@ -143,29 +149,23 @@ export const ChatWidget = memo(function ChatWidget({
     }
   };
 
+  const displayMessages = useMemo(
+    () => filterMessagesForThreadDepthError(messages, threadDepthError),
+    [messages, threadDepthError],
+  );
+
   // Group messages into exchanges (user + assistant pairs)
   const exchanges = useMemo(() => {
     const grouped: Exchange[] = [];
-    let skipLastUserMessage = false;
 
-    // If there's a thread depth error, don't show the last user message
-    if (hasThreadDepthError && messages.length > 0) {
-      const lastMessage = messages[messages.length - 1];
-      if (lastMessage.role === "user") {
-        skipLastUserMessage = true;
-      }
-    }
-
-    for (let i = 0; i < messages.length; i++) {
-      // Skip the last user message if it caused a thread depth error
-      if (skipLastUserMessage && i === messages.length - 1) {
+    for (let i = 0; i < displayMessages.length; i++) {
+      const current = displayMessages.slice(i, i + 1)[0];
+      if (!current) {
         continue;
       }
-
-      const current = messages[i];
       if (current.role === "user") {
         const userMessage = current as Message;
-        const nextMessage = messages[i + 1];
+        const nextMessage = displayMessages.slice(i + 1, i + 2)[0];
         if (nextMessage?.role === "assistant") {
           grouped.push({
             id: userMessage.id,
@@ -184,7 +184,7 @@ export const ChatWidget = memo(function ChatWidget({
       }
     }
     return grouped;
-  }, [messages, hasThreadDepthError]);
+  }, [displayMessages]);
 
   // Cleanup any pending reset timers on unmount
   useEffect(() => {
@@ -226,14 +226,14 @@ export const ChatWidget = memo(function ChatWidget({
           </div>
         ) : null}
         {/* thread depth error banner */}
-        {hasThreadDepthError && onNewChat && (
+        {showThreadDepthError ? (
           <ThreadDepthErrorBanner onNewChat={onNewChat} />
-        )}
+        ) : null}
         <p className="ss-hint">
           Answers are generated using AI and may make mistakes.
         </p>
-        {/* other errors - never show AI-217 errors here */}
-        {error && !hasThreadDepthError && !isThreadDepthError(error) && (
+        {/* other errors - never show AI-217 in the generic banner */}
+        {error && !isThreadDepthError(error) && (
           <div className="ss-error-banner">{error.message}</div>
         )}
 

--- a/packages/standalone/src/components/search-askai/chat.tsx
+++ b/packages/standalone/src/components/search-askai/chat.tsx
@@ -1,6 +1,14 @@
 import type { UIMessage } from "@ai-sdk/react";
 import type { UIDataTypes, UIMessagePart } from "ai";
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import type { SearchHit } from "../types";
 
 import { postAgentStudioFeedback, postFeedback } from "./askai";
@@ -45,11 +53,18 @@ interface ChatWidgetProps {
   applicationId: string;
   apiKey?: string;
   assistantId: string;
-  /** When true, feedback is sent to Agent Studio instead of the AskAI backend. */
   agentStudio?: boolean;
   suggestedQuestions?: SuggestedQuestionHit[];
   threadDepthError?: boolean;
   showThreadDepthError?: boolean;
+  threadDepthBannerInChat?: boolean;
+  /** When false, omit the AI disclaimer from the chat scroll area (e.g. show it in a sidepanel footer). */
+  showAiDisclaimer?: boolean;
+  /**
+   * When true (default), newest Q&A appears at the top (search-modal style).
+   * When false, chronological order: older turns at the top, latest at the bottom (typical chat / sidepanel).
+   */
+  newestExchangeFirst?: boolean;
   onSuggestedQuestionClick?: (question: string) => void;
   onNewChat?: () => void;
 }
@@ -101,8 +116,14 @@ export const ChatWidget = memo(function ChatWidget({
   onNewChat,
   threadDepthError = false,
   showThreadDepthError = false,
+  threadDepthBannerInChat = true,
+  showAiDisclaimer = true,
+  newestExchangeFirst = true,
 }: ChatWidgetProps) {
   const { copyText } = useClipboard();
+  const chatScrollRef = useRef<HTMLDivElement>(null);
+  /** When false, user has scrolled away from the bottom; avoid snapping on updates. */
+  const stickChatToBottomRef = useRef(true);
   const [copiedExchangeId, setCopiedExchangeId] = useState<string | null>(null);
   const copyResetTimeoutRef = useRef<number | null>(null);
   const [acknowledgedExchangeIds, setAcknowledgedExchangeIds] = useState<
@@ -159,13 +180,13 @@ export const ChatWidget = memo(function ChatWidget({
     const grouped: Exchange[] = [];
 
     for (let i = 0; i < displayMessages.length; i++) {
-      const current = displayMessages.slice(i, i + 1)[0];
+      const current = displayMessages.at(i);
       if (!current) {
         continue;
       }
       if (current.role === "user") {
         const userMessage = current as Message;
-        const nextMessage = displayMessages.slice(i + 1, i + 2)[0];
+        const nextMessage = displayMessages.at(i + 1);
         if (nextMessage?.role === "assistant") {
           grouped.push({
             id: userMessage.id,
@@ -186,6 +207,38 @@ export const ChatWidget = memo(function ChatWidget({
     return grouped;
   }, [displayMessages]);
 
+  const orderedExchanges = useMemo(
+    () => (newestExchangeFirst ? [...exchanges].reverse() : exchanges),
+    [exchanges, newestExchangeFirst],
+  );
+
+  const updateStickToBottomFromScroll = useCallback(() => {
+    if (newestExchangeFirst) return;
+    const root = chatScrollRef.current;
+    if (!root) return;
+    const thresholdPx = 80;
+    const dist = root.scrollHeight - root.scrollTop - root.clientHeight;
+    stickChatToBottomRef.current = dist < thresholdPx;
+  }, [newestExchangeFirst]);
+
+  // Scroll after DOM updates when transcript or generation state changes (not only when exchange count changes).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: displayMessages / isGenerating intentionally trigger stick-to-bottom
+  useLayoutEffect(() => {
+    if (newestExchangeFirst) return;
+    const root = chatScrollRef.current;
+    if (!root) return;
+    if (stickChatToBottomRef.current) {
+      root.scrollTop = root.scrollHeight;
+    }
+    updateStickToBottomFromScroll();
+  }, [
+    newestExchangeFirst,
+    displayMessages,
+    isGenerating,
+    orderedExchanges.length,
+    updateStickToBottomFromScroll,
+  ]);
+
   // Cleanup any pending reset timers on unmount
   useEffect(() => {
     return () => {
@@ -196,7 +249,11 @@ export const ChatWidget = memo(function ChatWidget({
   }, []);
 
   return (
-    <div className="ss-chat-root">
+    <div
+      className="ss-chat-root"
+      ref={chatScrollRef}
+      onScroll={updateStickToBottomFromScroll}
+    >
       <div className="ss-qa-list">
         {exchanges.length === 0 ? (
           <div className="ss-chat-welcome">
@@ -225,226 +282,220 @@ export const ChatWidget = memo(function ChatWidget({
             ) : null}
           </div>
         ) : null}
-        {/* thread depth error banner */}
-        {showThreadDepthError ? (
+        {threadDepthBannerInChat && showThreadDepthError ? (
           <ThreadDepthErrorBanner onNewChat={onNewChat} />
         ) : null}
-        <p className="ss-hint">
-          Answers are generated using AI and may make mistakes.
-        </p>
+        {showAiDisclaimer ? (
+          <p className="ss-hint">
+            Answers are generated with AI which can make mistakes.
+          </p>
+        ) : null}
         {/* other errors - never show AI-217 in the generic banner */}
         {error && !isThreadDepthError(error) && (
           <div className="ss-error-banner">{error.message}</div>
         )}
 
         {/* exchanges */}
-        {exchanges
-          .slice()
-          .reverse()
-          .map((exchange, index) => {
-            const isLastExchange = index === 0;
+        {orderedExchanges.map((exchange, index) => {
+          const isLastExchange = newestExchangeFirst
+            ? index === 0
+            : index === orderedExchanges.length - 1;
 
-            return (
-              <article key={exchange.id} className="ss-qa-card">
-                <div className="ss-qa-header">
-                  <div className="ss-qa-question">
-                    {exchange.userMessage.parts.map((part, index) =>
-                      part.type === "text" ? (
-                        // biome-ignore lint/suspicious/noArrayIndexKey: better
-                        <span key={index}>{part.text}</span>
-                      ) : null,
-                    )}
-                  </div>
+          return (
+            <article key={exchange.id} className="ss-qa-card">
+              <div className="ss-qa-header">
+                <div className="ss-qa-question">
+                  {exchange.userMessage.parts.map((part, index) =>
+                    part.type === "text" ? (
+                      // biome-ignore lint/suspicious/noArrayIndexKey: better
+                      <span key={index}>{part.text}</span>
+                    ) : null,
+                  )}
                 </div>
+              </div>
 
-                <div className="ss-qa-answer">
-                  <div className="ss-qa-answer-content">
-                    {exchange.assistantMessage ? (
-                      <div className="ss-qa-markdown">
-                        {exchange.assistantMessage.parts.map((part, index) => {
-                          if (typeof part === "string") {
+              <div className="ss-qa-answer">
+                <div className="ss-qa-answer-content">
+                  {exchange.assistantMessage ? (
+                    <div className="ss-qa-markdown">
+                      {exchange.assistantMessage.parts.map((part, index) => {
+                        if (typeof part === "string") {
+                          // biome-ignore lint/suspicious/noArrayIndexKey: better
+                          return <p key={`${index}`}>{part}</p>;
+                        }
+                        if (part.type === "text") {
+                          return (
                             // biome-ignore lint/suspicious/noArrayIndexKey: better
-                            return <p key={`${index}`}>{part}</p>;
-                          }
-                          if (part.type === "text") {
-                            return (
-                              // biome-ignore lint/suspicious/noArrayIndexKey: better
-                              <MemoizedMarkdown key={`${index}`}>
-                                {part.text}
-                              </MemoizedMarkdown>
-                            );
-                          } else if (
-                            part.type === "reasoning" &&
-                            part.state === "streaming"
-                          ) {
+                            <MemoizedMarkdown key={`${index}`}>
+                              {part.text}
+                            </MemoizedMarkdown>
+                          );
+                        } else if (
+                          part.type === "reasoning" &&
+                          part.state === "streaming"
+                        ) {
+                          return (
+                            // biome-ignore lint/suspicious/noArrayIndexKey: better
+                            <p className="ss-tool-info" key={`${index}`}>
+                              <BrainIcon />{" "}
+                              <span className="ss-shimmer-text">
+                                Reasoning...
+                              </span>
+                            </p>
+                          );
+                        } else if (part.type === "tool-searchIndex") {
+                          if (part.state === "input-streaming") {
                             return (
                               // biome-ignore lint/suspicious/noArrayIndexKey: better
                               <p className="ss-tool-info" key={`${index}`}>
-                                <BrainIcon />{" "}
+                                <SearchIcon size={18} />{" "}
                                 <span className="ss-shimmer-text">
-                                  Reasoning...
+                                  Searching...
                                 </span>
                               </p>
                             );
-                          } else if (part.type === "tool-searchIndex") {
-                            if (part.state === "input-streaming") {
-                              return (
-                                // biome-ignore lint/suspicious/noArrayIndexKey: better
-                                <p className="ss-tool-info" key={`${index}`}>
-                                  <SearchIcon size={18} />{" "}
-                                  <span className="ss-shimmer-text">
-                                    Searching...
-                                  </span>
-                                </p>
-                              );
-                            } else if (part.state === "input-available") {
-                              return (
-                                // biome-ignore lint/suspicious/noArrayIndexKey: better
-                                <p className="ss-tool-info" key={`${index}`}>
-                                  <SearchIcon size={18} />{" "}
-                                  <span className="ss-shimmer-text">
-                                    Looking for{" "}
-                                    <mark>
-                                      &quot;{part.input?.query || ""}&quot;
-                                    </mark>
-                                  </span>
-                                </p>
-                              );
-                            } else if (part.state === "output-available") {
-                              return (
-                                // biome-ignore lint/suspicious/noArrayIndexKey: better
-                                <p className="ss-tool-info" key={`${index}`}>
-                                  <SearchIcon size={18} />{" "}
-                                  <span>
-                                    Searched for{" "}
-                                    <mark>
-                                      &quot;{part.output?.query}&quot;
-                                    </mark>{" "}
-                                    found {part.output?.hits.length || "no"}{" "}
-                                    results
-                                  </span>
-                                </p>
-                              );
-                            } else if (part.state === "output-error") {
-                              return (
-                                // biome-ignore lint/suspicious/noArrayIndexKey: better
-                                <p className="ss-tool-info" key={`${index}`}>
-                                  {part.errorText}
-                                </p>
-                              );
-                            } else {
-                              return null;
-                            }
+                          } else if (part.state === "input-available") {
+                            return (
+                              // biome-ignore lint/suspicious/noArrayIndexKey: better
+                              <p className="ss-tool-info" key={`${index}`}>
+                                <SearchIcon size={18} />{" "}
+                                <span className="ss-shimmer-text">
+                                  Looking for{" "}
+                                  <mark>
+                                    &quot;{part.input?.query || ""}&quot;
+                                  </mark>
+                                </span>
+                              </p>
+                            );
+                          } else if (part.state === "output-available") {
+                            return (
+                              // biome-ignore lint/suspicious/noArrayIndexKey: better
+                              <p className="ss-tool-info" key={`${index}`}>
+                                <SearchIcon size={18} />{" "}
+                                <span>
+                                  Searched for{" "}
+                                  <mark>&quot;{part.output?.query}&quot;</mark>{" "}
+                                  found {part.output?.hits.length || "no"}{" "}
+                                  results
+                                </span>
+                              </p>
+                            );
+                          } else if (part.state === "output-error") {
+                            return (
+                              // biome-ignore lint/suspicious/noArrayIndexKey: better
+                              <p className="ss-tool-info" key={`${index}`}>
+                                {part.errorText}
+                              </p>
+                            );
                           } else {
                             return null;
                           }
-                        })}
-                      </div>
-                    ) : (
-                      <div className="ss-qa-markdown ss-qa-generating ss-shimmer-text">
-                        {isGenerating && isLastExchange ? "Thinking..." : ""}
-                      </div>
-                    )}
-                  </div>
-                </div>
-
-                <div className="ss-qa-actions">
-                  {exchange.assistantMessage && !isGenerating ? (
-                    acknowledgedExchangeIds.has(exchange.id) ? (
-                      <span className="ss-qa-feedback-ack ss-fade">
-                        Thanks for your feedback!
-                      </span>
-                    ) : submittingExchangeId === exchange.id ? (
-                      <span className="ss-qa-feedback-ack ss-shimmer-text">
-                        Submitting...
-                      </span>
-                    ) : (
-                      <div className="ss-qa-actions-group">
-                        <button
-                          type="button"
-                          title="Like"
-                          aria-label="Like"
-                          className="ss-qa-action-btn"
-                          disabled={
-                            !exchange.assistantMessage ||
-                            submittingExchangeId === exchange.id
-                          }
-                          onClick={() => handleFeedback(exchange, 1)}
-                        >
-                          <LikeIcon size={18} />
-                        </button>
-                        <button
-                          type="button"
-                          title="Dislike"
-                          aria-label="Dislike"
-                          className="ss-qa-action-btn"
-                          disabled={
-                            !exchange.assistantMessage ||
-                            submittingExchangeId === exchange.id
-                          }
-                          onClick={() => handleFeedback(exchange, 0)}
-                        >
-                          <DislikeIcon size={18} />
-                        </button>
-                      </div>
-                    )
-                  ) : null}
-                  <button
-                    type="button"
-                    className={`ss-qa-action-btn ${
-                      copiedExchangeId === exchange.id ? "is-copied" : ""
-                    }`}
-                    aria-label={
-                      copiedExchangeId === exchange.id
-                        ? "Copied"
-                        : "Copy answer"
-                    }
-                    title={
-                      copiedExchangeId === exchange.id
-                        ? "Copied"
-                        : "Copy answer"
-                    }
-                    disabled={
-                      !exchange.assistantMessage ||
-                      copiedExchangeId === exchange.id
-                    }
-                    onClick={async () => {
-                      const parts = exchange.assistantMessage?.parts ?? [];
-                      const textContent = parts
-                        .flatMap((part) =>
-                          part.type === "text" ? [part.text] : [],
-                        )
-                        .join("")
-                        .trim();
-                      if (!textContent) return;
-                      try {
-                        if (onCopy) {
-                          await onCopy(textContent);
                         } else {
-                          await copyText(textContent);
+                          return null;
                         }
-                        setCopiedExchangeId(exchange.id);
-                        if (copyResetTimeoutRef.current) {
-                          window.clearTimeout(copyResetTimeoutRef.current);
-                        }
-                        copyResetTimeoutRef.current = window.setTimeout(() => {
-                          setCopiedExchangeId(null);
-                        }, 1500);
-                      } catch {
-                        // noop – copy may fail silently
-                      }
-                    }}
-                  >
-                    {copiedExchangeId === exchange.id ? (
-                      <CheckIcon size={18} />
-                    ) : (
-                      <CopyIcon size={18} />
-                    )}
-                  </button>
+                      })}
+                    </div>
+                  ) : (
+                    <div className="ss-qa-markdown ss-qa-generating ss-shimmer-text">
+                      {isGenerating && isLastExchange ? "Thinking..." : ""}
+                    </div>
+                  )}
                 </div>
-              </article>
-            );
-          })}
+              </div>
+
+              <div className="ss-qa-actions">
+                {exchange.assistantMessage && !isGenerating ? (
+                  acknowledgedExchangeIds.has(exchange.id) ? (
+                    <span className="ss-qa-feedback-ack ss-fade">
+                      Thanks for your feedback!
+                    </span>
+                  ) : submittingExchangeId === exchange.id ? (
+                    <span className="ss-qa-feedback-ack ss-shimmer-text">
+                      Submitting...
+                    </span>
+                  ) : (
+                    <div className="ss-qa-actions-group">
+                      <button
+                        type="button"
+                        title="Like"
+                        aria-label="Like"
+                        className="ss-qa-action-btn"
+                        disabled={
+                          !exchange.assistantMessage ||
+                          submittingExchangeId === exchange.id
+                        }
+                        onClick={() => handleFeedback(exchange, 1)}
+                      >
+                        <LikeIcon size={18} />
+                      </button>
+                      <button
+                        type="button"
+                        title="Dislike"
+                        aria-label="Dislike"
+                        className="ss-qa-action-btn"
+                        disabled={
+                          !exchange.assistantMessage ||
+                          submittingExchangeId === exchange.id
+                        }
+                        onClick={() => handleFeedback(exchange, 0)}
+                      >
+                        <DislikeIcon size={18} />
+                      </button>
+                    </div>
+                  )
+                ) : null}
+                <button
+                  type="button"
+                  className={`ss-qa-action-btn ${
+                    copiedExchangeId === exchange.id ? "is-copied" : ""
+                  }`}
+                  aria-label={
+                    copiedExchangeId === exchange.id ? "Copied" : "Copy answer"
+                  }
+                  title={
+                    copiedExchangeId === exchange.id ? "Copied" : "Copy answer"
+                  }
+                  disabled={
+                    !exchange.assistantMessage ||
+                    copiedExchangeId === exchange.id
+                  }
+                  onClick={async () => {
+                    const parts = exchange.assistantMessage?.parts ?? [];
+                    const textContent = parts
+                      .flatMap((part) =>
+                        part.type === "text" ? [part.text] : [],
+                      )
+                      .join("")
+                      .trim();
+                    if (!textContent) return;
+                    try {
+                      if (onCopy) {
+                        await onCopy(textContent);
+                      } else {
+                        await copyText(textContent);
+                      }
+                      setCopiedExchangeId(exchange.id);
+                      if (copyResetTimeoutRef.current) {
+                        window.clearTimeout(copyResetTimeoutRef.current);
+                      }
+                      copyResetTimeoutRef.current = window.setTimeout(() => {
+                        setCopiedExchangeId(null);
+                      }, 1500);
+                    } catch {
+                      // noop – copy may fail silently
+                    }
+                  }}
+                >
+                  {copiedExchangeId === exchange.id ? (
+                    <CheckIcon size={18} />
+                  ) : (
+                    <CopyIcon size={18} />
+                  )}
+                </button>
+              </div>
+            </article>
+          );
+        })}
       </div>
     </div>
   );

--- a/packages/standalone/src/components/search-askai/chat.tsx
+++ b/packages/standalone/src/components/search-askai/chat.tsx
@@ -14,9 +14,9 @@ import type { SearchHit } from "../types";
 import { postAgentStudioFeedback, postFeedback } from "./askai";
 
 import {
-  filterMessagesForThreadDepthError,
   isThreadDepthError,
   ThreadDepthErrorBanner,
+  threadDepthErrorDetail,
 } from "./error-utils";
 import {
   BrainIcon,
@@ -55,7 +55,6 @@ interface ChatWidgetProps {
   assistantId: string;
   agentStudio?: boolean;
   suggestedQuestions?: SuggestedQuestionHit[];
-  threadDepthError?: boolean;
   showThreadDepthError?: boolean;
   threadDepthBannerInChat?: boolean;
   /** When false, omit the AI disclaimer from the chat scroll area (e.g. show it in a sidepanel footer). */
@@ -114,7 +113,6 @@ export const ChatWidget = memo(function ChatWidget({
   suggestedQuestions,
   onSuggestedQuestionClick,
   onNewChat,
-  threadDepthError = false,
   showThreadDepthError = false,
   threadDepthBannerInChat = true,
   showAiDisclaimer = true,
@@ -170,23 +168,18 @@ export const ChatWidget = memo(function ChatWidget({
     }
   };
 
-  const displayMessages = useMemo(
-    () => filterMessagesForThreadDepthError(messages, threadDepthError),
-    [messages, threadDepthError],
-  );
-
   // Group messages into exchanges (user + assistant pairs)
   const exchanges = useMemo(() => {
     const grouped: Exchange[] = [];
 
-    for (let i = 0; i < displayMessages.length; i++) {
-      const current = displayMessages.at(i);
+    for (let i = 0; i < messages.length; i++) {
+      const current = messages.at(i);
       if (!current) {
         continue;
       }
       if (current.role === "user") {
         const userMessage = current as Message;
-        const nextMessage = displayMessages.at(i + 1);
+        const nextMessage = messages.at(i + 1);
         if (nextMessage?.role === "assistant") {
           grouped.push({
             id: userMessage.id,
@@ -205,7 +198,7 @@ export const ChatWidget = memo(function ChatWidget({
       }
     }
     return grouped;
-  }, [displayMessages]);
+  }, [messages]);
 
   const orderedExchanges = useMemo(
     () => (newestExchangeFirst ? [...exchanges].reverse() : exchanges),
@@ -222,7 +215,7 @@ export const ChatWidget = memo(function ChatWidget({
   }, [newestExchangeFirst]);
 
   // Scroll after DOM updates when transcript or generation state changes (not only when exchange count changes).
-  // biome-ignore lint/correctness/useExhaustiveDependencies: displayMessages / isGenerating intentionally trigger stick-to-bottom
+  // biome-ignore lint/correctness/useExhaustiveDependencies: messages / isGenerating intentionally trigger stick-to-bottom
   useLayoutEffect(() => {
     if (newestExchangeFirst) return;
     const root = chatScrollRef.current;
@@ -233,7 +226,7 @@ export const ChatWidget = memo(function ChatWidget({
     updateStickToBottomFromScroll();
   }, [
     newestExchangeFirst,
-    displayMessages,
+    messages,
     isGenerating,
     orderedExchanges.length,
     updateStickToBottomFromScroll,
@@ -283,7 +276,10 @@ export const ChatWidget = memo(function ChatWidget({
           </div>
         ) : null}
         {threadDepthBannerInChat && showThreadDepthError ? (
-          <ThreadDepthErrorBanner onNewChat={onNewChat} />
+          <ThreadDepthErrorBanner
+            onNewChat={onNewChat}
+            detailMessage={threadDepthErrorDetail(error)}
+          />
         ) : null}
         {showAiDisclaimer ? (
           <p className="ss-hint">

--- a/packages/standalone/src/components/search-askai/error-utils.tsx
+++ b/packages/standalone/src/components/search-askai/error-utils.tsx
@@ -50,26 +50,22 @@ export function isThreadDepthError(error?: unknown): boolean {
   return messageLooksLikeThreadDepth(errorMessage(error));
 }
 
-type MessageWithRole = { role: string };
-
 /**
- * When thread depth is exceeded, the last user turn has no assistant reply — omit it so the UI
- * only shows successful exchanges (same behavior as DocSearch modal / sidepanel).
+ * Human-readable thread-depth text from the API (plain `Error.message` or JSON `{"message":"…"}`).
  */
-export function filterMessagesForThreadDepthError<T extends MessageWithRole>(
-  messages: T[],
-  threadDepthError: boolean,
-): T[] {
-  if (!threadDepthError || messages.length === 0) {
-    return messages;
+export function threadDepthErrorDetail(error?: unknown): string | undefined {
+  if (!isThreadDepthError(error)) return undefined;
+  const raw = errorMessage(error).trim();
+  if (!raw) return undefined;
+  try {
+    const parsed = JSON.parse(raw) as { message?: string };
+    if (typeof parsed.message === "string" && parsed.message.trim()) {
+      return parsed.message.trim();
+    }
+  } catch {
+    // `message` is not JSON — use as-is below
   }
-
-  const last = messages[messages.length - 1];
-  if (last.role === "user") {
-    return messages.slice(0, -1);
-  }
-
-  return messages;
+  return raw;
 }
 
 /**
@@ -77,6 +73,7 @@ export function filterMessagesForThreadDepthError<T extends MessageWithRole>(
  */
 export interface ThreadDepthErrorBannerProps {
   onNewChat?: () => void;
+  detailMessage?: string;
 }
 
 /**
@@ -85,22 +82,28 @@ export interface ThreadDepthErrorBannerProps {
  */
 export const ThreadDepthErrorBanner = ({
   onNewChat,
+  detailMessage,
 }: ThreadDepthErrorBannerProps) => (
   <div className="ss-thread-depth-error-banner">
-    This conversation is now closed to keep responses accurate.{" "}
-    {onNewChat ? (
-      <button
-        type="button"
-        className="ss-thread-depth-error-link"
-        onClick={onNewChat}
-      >
-        Start a new conversation
-      </button>
-    ) : (
-      <span className="ss-thread-depth-error-cta">
-        Start a new conversation
-      </span>
-    )}{" "}
-    to continue.
+    {detailMessage ? (
+      <p className="ss-thread-depth-error-detail">{detailMessage}</p>
+    ) : null}
+    <p className="ss-thread-depth-error-main">
+      This conversation is now closed to keep responses accurate.{" "}
+      {onNewChat ? (
+        <button
+          type="button"
+          className="ss-thread-depth-error-link"
+          onClick={onNewChat}
+        >
+          Start a new conversation
+        </button>
+      ) : (
+        <span className="ss-thread-depth-error-cta">
+          Start a new conversation
+        </span>
+      )}{" "}
+      to continue.
+    </p>
   </div>
 );

--- a/packages/standalone/src/components/search-askai/error-utils.tsx
+++ b/packages/standalone/src/components/search-askai/error-utils.tsx
@@ -1,31 +1,82 @@
 /**
  * Utility functions and components for handling AI errors
+ * (aligned with DocSearch `utils/ai` thread-depth handling for Agent Studio JSON bodies)
  */
+
+function threadDepthFromPlainText(message: string): boolean {
+  if (!message) return false;
+  if (message.toUpperCase().includes("AI-217")) return true;
+  return /thread\s+depth/i.test(message);
+}
+
+function messageLooksLikeThreadDepth(message: string): boolean {
+  if (threadDepthFromPlainText(message)) return true;
+
+  try {
+    const parsed = JSON.parse(message) as {
+      code?: string;
+      errorCode?: string;
+      message?: string;
+    };
+    const code = parsed.code ?? parsed.errorCode;
+    if (typeof code === "string" && code.toUpperCase() === "AI-217") {
+      return true;
+    }
+    const nested = typeof parsed.message === "string" ? parsed.message : "";
+    return threadDepthFromPlainText(nested);
+  } catch {
+    return false;
+  }
+}
+
+function errorMessage(error: unknown): string {
+  if (error == null) return "";
+  if (error instanceof Error) return error.message ?? "";
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof (error as { message: unknown }).message === "string"
+  ) {
+    return (error as { message: string }).message;
+  }
+  return "";
+}
 
 /**
- * Checks if an error is a thread depth error (AI-217)
- * Thread depth errors occur when a conversation has reached its maximum depth limit
- *
- * @param error - The error to check
- * @returns true if the error is a thread depth error (AI-217)
+ * Whether the error is thread depth exceeded (AI-217), including JSON-shaped Agent Studio payloads in `message`.
  */
-export function isThreadDepthError(error?: Error | null): boolean {
-  if (!error) return false;
+export function isThreadDepthError(error?: unknown): boolean {
+  return messageLooksLikeThreadDepth(errorMessage(error));
+}
 
-  // Check if error has a code property
-  const errorWithCode = error as Error & { code?: string };
-  if (errorWithCode.code === "AI-217") return true;
+type MessageWithRole = { role: string };
 
-  // Check message content for AI-217 or thread depth references
-  const message = error.message?.toLowerCase() || "";
-  return message.includes("ai-217") || message.includes("thread depth");
+/**
+ * When thread depth is exceeded, the last user turn has no assistant reply — omit it so the UI
+ * only shows successful exchanges (same behavior as DocSearch modal / sidepanel).
+ */
+export function filterMessagesForThreadDepthError<T extends MessageWithRole>(
+  messages: T[],
+  threadDepthError: boolean,
+): T[] {
+  if (!threadDepthError || messages.length === 0) {
+    return messages;
+  }
+
+  const last = messages[messages.length - 1];
+  if (last.role === "user") {
+    return messages.slice(0, -1);
+  }
+
+  return messages;
 }
 
 /**
  * Props for ThreadDepthErrorBanner component
  */
 export interface ThreadDepthErrorBannerProps {
-  onNewChat: () => void;
+  onNewChat?: () => void;
 }
 
 /**
@@ -37,13 +88,19 @@ export const ThreadDepthErrorBanner = ({
 }: ThreadDepthErrorBannerProps) => (
   <div className="ss-thread-depth-error-banner">
     This conversation is now closed to keep responses accurate.{" "}
-    <button
-      type="button"
-      className="ss-thread-depth-error-link"
-      onClick={onNewChat}
-    >
-      Start a new conversation
-    </button>{" "}
+    {onNewChat ? (
+      <button
+        type="button"
+        className="ss-thread-depth-error-link"
+        onClick={onNewChat}
+      >
+        Start a new conversation
+      </button>
+    ) : (
+      <span className="ss-thread-depth-error-cta">
+        Start a new conversation
+      </span>
+    )}{" "}
     to continue.
   </div>
 );

--- a/packages/standalone/src/components/search-askai/icons.tsx
+++ b/packages/standalone/src/components/search-askai/icons.tsx
@@ -58,103 +58,117 @@ export const CopyIcon = ({ size = 24, color = "currentColor" }: IconProps) => (
   </svg>
 );
 
-export const SparklesIcon = ({ size = 24 }: IconProps) => (
-  <svg
-    width={size}
-    height={size}
-    viewBox="0 0 16 16"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path
-      fillRule="evenodd"
-      clipRule="evenodd"
-      d="M8 1.5a.5.5 0 0 1 .475.344L9.75 5.719a.833.833 0 0 0 .53.531l3.876 1.275a.5.5 0 0 1 0 .95L10.281 9.75a.833.833 0 0 0-.531.53l-1.275 3.876a.5.5 0 0 1-.95 0L6.25 10.281a.833.833 0 0 0-.53-.531L1.843 8.475a.5.5 0 0 1 0-.95L5.719 6.25a.833.833 0 0 0 .531-.53l1.275-3.876A.5.5 0 0 1 8 1.5Zm-.8 4.532A1.833 1.833 0 0 1 6.032 7.2L3.6 8l2.432.8A1.833 1.833 0 0 1 7.2 9.968L8 12.4l.8-2.432A1.833 1.833 0 0 1 9.968 8.8L12.4 8l-2.432-.8A1.833 1.833 0 0 1 8.8 6.032L8 3.6l-.8 2.432Z"
-      fill="url(#8aa5f4b5___a)"
-    ></path>
-    <path
-      fillRule="evenodd"
-      clipRule="evenodd"
-      d="M3.333 1.5a.5.5 0 0 1 .5.5v2.667a.5.5 0 1 1-1 0V2a.5.5 0 0 1 .5-.5Z"
-      fill="url(#8aa5f4b5___b)"
-    ></path>
-    <path
-      fillRule="evenodd"
-      clipRule="evenodd"
-      d="M12.667 10.833a.5.5 0 0 1 .5.5V14a.5.5 0 0 1-1 0v-2.667a.5.5 0 0 1 .5-.5Z"
-      fill="url(#8aa5f4b5___c)"
-    ></path>
-    <path
-      fillRule="evenodd"
-      clipRule="evenodd"
-      d="M1.5 3.333a.5.5 0 0 1 .5-.5h2.667a.5.5 0 0 1 0 1H2a.5.5 0 0 1-.5-.5Z"
-      fill="url(#8aa5f4b5___d)"
-    ></path>
-    <path
-      fillRule="evenodd"
-      clipRule="evenodd"
-      d="M10.833 12.667a.5.5 0 0 1 .5-.5H14a.5.5 0 1 1 0 1h-2.667a.5.5 0 0 1-.5-.5Z"
-      fill="url(#8aa5f4b5___e)"
-    ></path>
-    <defs>
-      <linearGradient
-        id="8aa5f4b5___a"
-        x1="15.03"
-        y1="8"
-        x2="2.03"
-        y2="8"
-        gradientUnits="userSpaceOnUse"
-      >
-        <stop offset="0.15" stopColor="#8E00FC"></stop>
-        <stop offset="1" stopColor="#003DFF"></stop>
-      </linearGradient>
-      <linearGradient
-        id="8aa5f4b5___b"
-        x1="15.03"
-        y1="8"
-        x2="2.03"
-        y2="8"
-        gradientUnits="userSpaceOnUse"
-      >
-        <stop offset="0.15" stopColor="#8E00FC"></stop>
-        <stop offset="1" stopColor="#003DFF"></stop>
-      </linearGradient>
-      <linearGradient
-        id="8aa5f4b5___c"
-        x1="15.03"
-        y1="8"
-        x2="2.03"
-        y2="8"
-        gradientUnits="userSpaceOnUse"
-      >
-        <stop offset="0.15" stopColor="#8E00FC"></stop>
-        <stop offset="1" stopColor="#003DFF"></stop>
-      </linearGradient>
-      <linearGradient
-        id="8aa5f4b5___d"
-        x1="15.03"
-        y1="8"
-        x2="2.03"
-        y2="8"
-        gradientUnits="userSpaceOnUse"
-      >
-        <stop offset="0.15" stopColor="#8E00FC"></stop>
-        <stop offset="1" stopColor="#003DFF"></stop>
-      </linearGradient>
-      <linearGradient
-        id="8aa5f4b5___e"
-        x1="15.03"
-        y1="8"
-        x2="2.03"
-        y2="8"
-        gradientUnits="userSpaceOnUse"
-      >
-        <stop offset="0.15" stopColor="#8E00FC"></stop>
-        <stop offset="1" stopColor="#003DFF"></stop>
-      </linearGradient>
-    </defs>
-  </svg>
-);
+type SparklesIconProps = IconProps & {
+  /** Append to gradient ids when multiple sparkles SVGs share one document (avoids id clashes). */
+  gradientIdSuffix?: string;
+};
+
+export const SparklesIcon = ({
+  size = 24,
+  className,
+  gradientIdSuffix = "",
+}: SparklesIconProps) => {
+  const g = (base: string) => `${base}${gradientIdSuffix}`;
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      aria-hidden
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M8 1.5a.5.5 0 0 1 .475.344L9.75 5.719a.833.833 0 0 0 .53.531l3.876 1.275a.5.5 0 0 1 0 .95L10.281 9.75a.833.833 0 0 0-.531.53l-1.275 3.876a.5.5 0 0 1-.95 0L6.25 10.281a.833.833 0 0 0-.53-.531L1.843 8.475a.5.5 0 0 1 0-.95L5.719 6.25a.833.833 0 0 0 .531-.53l1.275-3.876A.5.5 0 0 1 8 1.5Zm-.8 4.532A1.833 1.833 0 0 1 6.032 7.2L3.6 8l2.432.8A1.833 1.833 0 0 1 7.2 9.968L8 12.4l.8-2.432A1.833 1.833 0 0 1 9.968 8.8L12.4 8l-2.432-.8A1.833 1.833 0 0 1 8.8 6.032L8 3.6l-.8 2.432Z"
+        fill={`url(#${g("8aa5f4b5___a")})`}
+      ></path>
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M3.333 1.5a.5.5 0 0 1 .5.5v2.667a.5.5 0 1 1-1 0V2a.5.5 0 0 1 .5-.5Z"
+        fill={`url(#${g("8aa5f4b5___b")})`}
+      ></path>
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M12.667 10.833a.5.5 0 0 1 .5.5V14a.5.5 0 0 1-1 0v-2.667a.5.5 0 0 1 .5-.5Z"
+        fill={`url(#${g("8aa5f4b5___c")})`}
+      ></path>
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M1.5 3.333a.5.5 0 0 1 .5-.5h2.667a.5.5 0 0 1 0 1H2a.5.5 0 0 1-.5-.5Z"
+        fill={`url(#${g("8aa5f4b5___d")})`}
+      ></path>
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M10.833 12.667a.5.5 0 0 1 .5-.5H14a.5.5 0 1 1 0 1h-2.667a.5.5 0 0 1-.5-.5Z"
+        fill={`url(#${g("8aa5f4b5___e")})`}
+      ></path>
+      <defs>
+        <linearGradient
+          id={g("8aa5f4b5___a")}
+          x1="15.03"
+          y1="8"
+          x2="2.03"
+          y2="8"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset="0.15" stopColor="#8E00FC"></stop>
+          <stop offset="1" stopColor="#003DFF"></stop>
+        </linearGradient>
+        <linearGradient
+          id={g("8aa5f4b5___b")}
+          x1="15.03"
+          y1="8"
+          x2="2.03"
+          y2="8"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset="0.15" stopColor="#8E00FC"></stop>
+          <stop offset="1" stopColor="#003DFF"></stop>
+        </linearGradient>
+        <linearGradient
+          id={g("8aa5f4b5___c")}
+          x1="15.03"
+          y1="8"
+          x2="2.03"
+          y2="8"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset="0.15" stopColor="#8E00FC"></stop>
+          <stop offset="1" stopColor="#003DFF"></stop>
+        </linearGradient>
+        <linearGradient
+          id={g("8aa5f4b5___d")}
+          x1="15.03"
+          y1="8"
+          x2="2.03"
+          y2="8"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset="0.15" stopColor="#8E00FC"></stop>
+          <stop offset="1" stopColor="#003DFF"></stop>
+        </linearGradient>
+        <linearGradient
+          id={g("8aa5f4b5___e")}
+          x1="15.03"
+          y1="8"
+          x2="2.03"
+          y2="8"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset="0.15" stopColor="#8E00FC"></stop>
+          <stop offset="1" stopColor="#003DFF"></stop>
+        </linearGradient>
+      </defs>
+    </svg>
+  );
+};
 
 export const SearchIcon = ({
   size = 24,
@@ -328,5 +342,25 @@ export const SquarePenIcon = ({
   >
     <path d="M12 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
     <path d="M18.375 2.625a1 1 0 0 1 3 3l-9.013 9.014a2 2 0 0 1-.853.505l-2.873.84a.5.5 0 0 1-.62-.62l.84-2.873a2 2 0 0 1 .506-.852z" />
+  </svg>
+);
+
+export const ChatSubmitIcon = ({
+  size = 22,
+  color = "currentColor",
+}: IconProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={color}
+    strokeWidth="2.25"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="m5 12 7-7 7 7" />
+    <path d="M12 19V5" />
   </svg>
 );

--- a/packages/standalone/src/components/search-askai/index.tsx
+++ b/packages/standalone/src/components/search-askai/index.tsx
@@ -326,10 +326,10 @@ export function SearchModal({ onClose, config }: SearchModalProps) {
   // Lift chat state here to thread isGenerating to the SearchInput
   const {
     messages,
-    setMessages,
     error,
     isGenerating,
     sendMessage,
+    startNewConversation,
     threadDepthError,
     showThreadDepthError,
   } = useAskai({
@@ -389,14 +389,24 @@ export function SearchModal({ onClose, config }: SearchModalProps) {
   const showResultsPanel = (!noResults && !!query) || showChat;
 
   const handleNewChat = useCallback(() => {
-    // Clear messages to start a fresh conversation
-    setMessages([]);
+    startNewConversation();
     setShowChat(true);
     refine("");
     if (inputRef.current) {
       inputRef.current.focus();
     }
-  }, [setMessages, setShowChat, refine]);
+  }, [startNewConversation, setShowChat, refine]);
+
+  /** Leaving chat while thread-depth failed: reset thread so Ask AI works again without closing the modal. */
+  const handleSetShowChat = useCallback(
+    (v: boolean) => {
+      if (!v && threadDepthError) {
+        startNewConversation();
+      }
+      setShowChat(v);
+    },
+    [setShowChat, threadDepthError, startNewConversation],
+  );
 
   return (
     <>
@@ -413,7 +423,7 @@ export function SearchModal({ onClose, config }: SearchModalProps) {
           showChat={showChat}
           isGenerating={isGenerating}
           isThreadDepthError={showThreadDepthError}
-          setShowChat={setShowChat}
+          setShowChat={handleSetShowChat}
           onClose={onClose}
           onArrowDown={moveDown}
           onArrowUp={moveUp}
@@ -433,9 +443,7 @@ export function SearchModal({ onClose, config }: SearchModalProps) {
           <ResultsPanel
             showChat={showChat}
             inputRef={inputRef}
-            setShowChat={(v) => {
-              setShowChat(v);
-            }}
+            setShowChat={handleSetShowChat}
             query={query}
             selectedIndex={selectedIndex}
             refine={refine}

--- a/packages/standalone/src/components/search-askai/index.tsx
+++ b/packages/standalone/src/components/search-askai/index.tsx
@@ -163,7 +163,6 @@ interface ResultsPanelProps {
   ) => void;
   suggestedQuestions?: SuggestedQuestionHit[];
   onNewChat?: () => void;
-  threadDepthError?: boolean;
   showThreadDepthError?: boolean;
   openResultsInNewTab?: boolean;
 }
@@ -185,7 +184,6 @@ const ResultsPanel: FC<ResultsPanelProps> = memo(function ResultsPanel({
   sendEvent,
   suggestedQuestions,
   onNewChat,
-  threadDepthError,
   showThreadDepthError,
   openResultsInNewTab = true,
 }) {
@@ -271,7 +269,6 @@ const ResultsPanel: FC<ResultsPanelProps> = memo(function ResultsPanel({
         suggestedQuestions={suggestedQuestions}
         onSuggestedQuestionClick={handleSuggestedQuestionClick}
         onNewChat={onNewChat}
-        threadDepthError={threadDepthError}
         showThreadDepthError={showThreadDepthError}
       />
     );
@@ -457,7 +454,6 @@ export function SearchModal({ onClose, config }: SearchModalProps) {
             sendEvent={sendEvent}
             suggestedQuestions={suggestedQuestions}
             onNewChat={handleNewChat}
-            threadDepthError={threadDepthError}
             showThreadDepthError={showThreadDepthError}
             openResultsInNewTab={config.openResultsInNewTab}
           />

--- a/packages/standalone/src/components/search-askai/index.tsx
+++ b/packages/standalone/src/components/search-askai/index.tsx
@@ -163,7 +163,8 @@ interface ResultsPanelProps {
   ) => void;
   suggestedQuestions?: SuggestedQuestionHit[];
   onNewChat?: () => void;
-  hasThreadDepthError?: boolean;
+  threadDepthError?: boolean;
+  showThreadDepthError?: boolean;
   openResultsInNewTab?: boolean;
 }
 
@@ -184,7 +185,8 @@ const ResultsPanel: FC<ResultsPanelProps> = memo(function ResultsPanel({
   sendEvent,
   suggestedQuestions,
   onNewChat,
-  hasThreadDepthError,
+  threadDepthError,
+  showThreadDepthError,
   openResultsInNewTab = true,
 }) {
   const { items } = useHits(
@@ -269,7 +271,8 @@ const ResultsPanel: FC<ResultsPanelProps> = memo(function ResultsPanel({
         suggestedQuestions={suggestedQuestions}
         onSuggestedQuestionClick={handleSuggestedQuestionClick}
         onNewChat={onNewChat}
-        hasThreadDepthError={hasThreadDepthError}
+        threadDepthError={threadDepthError}
+        showThreadDepthError={showThreadDepthError}
       />
     );
   }
@@ -327,7 +330,8 @@ export function SearchModal({ onClose, config }: SearchModalProps) {
     error,
     isGenerating,
     sendMessage,
-    hasThreadDepthError,
+    threadDepthError,
+    showThreadDepthError,
   } = useAskai({
     applicationId: config.applicationId,
     apiKey: config.apiKey,
@@ -408,7 +412,7 @@ export function SearchModal({ onClose, config }: SearchModalProps) {
           refine={refine}
           showChat={showChat}
           isGenerating={isGenerating}
-          isThreadDepthError={hasThreadDepthError}
+          isThreadDepthError={showThreadDepthError}
           setShowChat={setShowChat}
           onClose={onClose}
           onArrowDown={moveDown}
@@ -445,7 +449,8 @@ export function SearchModal({ onClose, config }: SearchModalProps) {
             sendEvent={sendEvent}
             suggestedQuestions={suggestedQuestions}
             onNewChat={handleNewChat}
-            hasThreadDepthError={hasThreadDepthError}
+            threadDepthError={threadDepthError}
+            showThreadDepthError={showThreadDepthError}
             openResultsInNewTab={config.openResultsInNewTab}
           />
         )}

--- a/packages/standalone/src/components/search-askai/search-input.tsx
+++ b/packages/standalone/src/components/search-askai/search-input.tsx
@@ -180,7 +180,17 @@ export const SearchInput = memo(function SearchInput(props: SearchInputProps) {
           <button
             type="button"
             className="ss-search-new-chat-button"
-            disabled={props.isGenerating}
+            disabled={props.isGenerating && !props.isThreadDepthError}
+            title={
+              props.isThreadDepthError
+                ? "Start a new conversation"
+                : "New conversation"
+            }
+            aria-label={
+              props.isThreadDepthError
+                ? "Start a new conversation"
+                : "New conversation"
+            }
             onClick={() => {
               setChatInput("");
               props.onNewChat?.();

--- a/packages/standalone/src/components/search-askai/search-input.tsx
+++ b/packages/standalone/src/components/search-askai/search-input.tsx
@@ -85,15 +85,22 @@ export const SearchInput = memo(function SearchInput(props: SearchInputProps) {
     : props.isGenerating
       ? "Answering..."
       : props.showChat
-        ? "Ask AI anything about Algolia"
+        ? "Ask AI anything"
         : props.placeholder;
 
   const currentValue = props.showChat ? chatInput : query || "";
   const isInputDisabled = props.isGenerating || props.isThreadDepthError;
 
+  const formClassName = [
+    props.className,
+    props.showChat ? "ss-searchbox-form--chat" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
   return (
     <search
-      className={props.className}
+      className={formClassName}
       onSubmit={(event) => {
         event.preventDefault();
         event.stopPropagation();
@@ -146,7 +153,6 @@ export const SearchInput = memo(function SearchInput(props: SearchInputProps) {
             e.preventDefault();
             const valueAtEnter = props.showChat ? chatInput : query || "";
             if (props.onEnter?.(valueAtEnter)) {
-              // If handled by parent (e.g., send in chat), clear the input
               if (props.showChat) {
                 setChatInput("");
               } else {
@@ -156,7 +162,6 @@ export const SearchInput = memo(function SearchInput(props: SearchInputProps) {
             }
             const trimmed = valueAtEnter.trim();
             if (trimmed) {
-              // Open chat; parent will send the query
               props.setShowChat(true);
             }
           }

--- a/packages/standalone/src/components/search-askai/styles.css
+++ b/packages/standalone/src/components/search-askai/styles.css
@@ -472,6 +472,16 @@
   border: 1px solid #fcd34d;
 }
 
+.ssask-exp .ss-thread-depth-error-detail {
+  margin: 0 0 0.65rem;
+  font-weight: 600;
+  color: inherit;
+}
+
+.ssask-exp .ss-thread-depth-error-main {
+  margin: 0;
+}
+
 .ssask-exp.dark .ss-thread-depth-error-banner {
   color: #fef9c3;
   background: rgba(250, 204, 21, 0.12);

--- a/packages/standalone/src/components/search-askai/styles.css
+++ b/packages/standalone/src/components/search-askai/styles.css
@@ -58,6 +58,20 @@
   /* Animations */
   --search-transition-duration: 150ms;
   --search-transform-hover: translateY(-1px);
+
+  /* Markdown / code (Ask AI chat) */
+  --search-markdown-code-block-bg: #f1f5f9;
+  --search-markdown-code-block-color: #1e293b;
+  --search-markdown-code-inline-bg: rgba(30, 41, 59, 0.08);
+  --search-markdown-code-inline-border: rgba(30, 41, 59, 0.14);
+  --search-markdown-copy-btn-bg: rgba(255, 255, 255, 0.94);
+  --search-markdown-copy-btn-hover-bg: #ffffff;
+  --search-markdown-copy-btn-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+
+  /* Ask AI composer send (neutral chip, React reference) */
+  --search-composer-submit-bg: #e5e7eb;
+  --search-composer-submit-bg-hover: #d1d5db;
+  --search-composer-submit-icon: #374151;
 }
 
 /* Dark theme overrides */
@@ -72,6 +86,16 @@
   --search-text-color: #e5e7eb;
   --search-border-color: #374151;
   --search-hover-color: #1f2937;
+  --search-markdown-code-block-bg: #12131a;
+  --search-markdown-code-block-color: #c5cad3;
+  --search-markdown-code-inline-bg: rgba(255, 255, 255, 0.07);
+  --search-markdown-code-inline-border: rgba(255, 255, 255, 0.12);
+  --search-markdown-copy-btn-bg: rgba(18, 19, 26, 0.96);
+  --search-markdown-copy-btn-hover-bg: #1a1b24;
+  --search-markdown-copy-btn-shadow: 0 2px 10px rgba(0, 0, 0, 0.35);
+  --search-composer-submit-bg: #cbd5e1;
+  --search-composer-submit-bg-hover: #b8c4d4;
+  --search-composer-submit-icon: #1e293b;
 }
 
 .ssask-exp .ss-tool-info {
@@ -152,6 +176,26 @@
   color: var(--search-secondary-color);
 }
 
+.ssask-exp .ss-searchbox-form.ss-searchbox-form--chat {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  border: 1px solid var(--search-primary-color);
+  border-radius: 0.5rem;
+  margin: 1rem 1rem 0.75rem;
+  box-shadow: none;
+  background-color: var(--search-background-color);
+  padding: 0.4rem 0.55rem;
+  gap: 0.35rem;
+}
+
+.ssask-exp .ss-searchbox-form.ss-searchbox-form--chat input {
+  line-height: 1.25;
+  padding-block: 0.1rem;
+  margin: 0;
+  align-self: center;
+}
+
 .ssask-exp .ss-search-clear-button {
   background-color: transparent;
   border: none;
@@ -203,7 +247,8 @@
 }
 
 .ssask-exp .ss-searchbox-form input {
-  width: 90%;
+  flex: 1;
+  min-width: 0;
   outline: none;
   font-family: inherit;
   background-color: transparent;
@@ -243,9 +288,11 @@
   flex-direction: column;
   max-height: var(--search-results-max-height);
   min-height: var(--search-results-max-height);
+  min-width: 0;
   padding: var(--search-results-padding);
   background-color: var(--search-background-color);
   overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .ssask-exp .ss-ask-ai-btn {
@@ -479,6 +526,8 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .ssask-exp .ss-chat-welcome {
@@ -533,6 +582,9 @@
   background: var(--search-neutral-color);
   box-shadow: var(--search-chat-card-shadow);
   padding: var(--search-chat-card-padding);
+  min-width: 0;
+  max-width: 100%;
+  box-sizing: border-box;
 }
 
 .ssask-exp .ss-qa-header {
@@ -553,15 +605,21 @@
   display: flex;
   align-items: flex-start;
   gap: 0.75rem;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .ssask-exp .ss-qa-answer-content {
   flex: 1;
   gap: 0.75rem;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .ssask-exp .ss-qa-markdown {
   color: var(--search-text-color);
+  min-width: 0;
+  max-width: 100%;
 }
 
 .ssask-exp .ss-qa-generating {
@@ -659,6 +717,8 @@
   font-size: 0.9rem;
   margin: 0;
   color: #6b7280;
+  text-align: left;
+  align-self: stretch;
 }
 
 /* footer */
@@ -712,6 +772,39 @@
   align-items: center;
   gap: 0.5rem;
   margin-left: auto;
+  flex-shrink: 0;
+}
+
+.ssask-exp .ss-search-submit-chat-button {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0;
+  border: none;
+  border-radius: var(--search-button-border-radius);
+  background: var(--search-composer-submit-bg);
+  color: var(--search-composer-submit-icon);
+  cursor: pointer;
+  transition: var(--search-button-transition);
+  align-self: center;
+}
+
+.ssask-exp .ss-search-submit-chat-button:hover:not(:disabled) {
+  background: var(--search-composer-submit-bg-hover);
+  color: var(--search-composer-submit-icon);
+}
+
+.ssask-exp .ss-search-submit-chat-button:focus-visible {
+  outline: 2px solid var(--search-primary-color);
+  outline-offset: 2px;
+}
+
+.ssask-exp .ss-search-submit-chat-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
 }
 
 .ssask-exp .ss-kbd {
@@ -916,7 +1009,8 @@
 .ss-markdown-content {
   color: var(--search-text-color);
   line-height: 1.6;
-  max-width: none;
+  max-width: 100%;
+  min-width: 0;
   display: flex;
   flex-direction: column;
 }
@@ -1016,14 +1110,18 @@
 
 /* Inline Code */
 .ss-markdown-content code:not(.ss-markdown-code-snippet code) {
-  background-color: rgba(175, 184, 193, 0.2);
+  background-color: var(
+    --search-markdown-code-inline-bg,
+    rgba(175, 184, 193, 0.2)
+  );
   color: var(--search-text-color);
   font-size: 0.875rem;
   font-family: ui-monospace, SFMono-Regular, "SF Mono", Consolas,
     "Liberation Mono", Menlo, monospace;
   padding: 0.125rem 0.25rem;
   border-radius: 0.25rem;
-  border: 1px solid rgba(175, 184, 193, 0.3);
+  border: 1px solid
+    var(--search-markdown-code-inline-border, rgba(175, 184, 193, 0.3));
 }
 
 /* Code blocks */
@@ -1032,24 +1130,31 @@
   margin: 1rem 0;
   border-radius: 0.5rem;
   overflow: hidden;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
   border: 1px solid var(--search-border-color);
-  background: #f8f9fa;
+  background: var(--search-markdown-code-block-bg, #f8f9fa);
 }
 
 .ss-markdown-code-snippet pre {
   margin: 0;
   padding: 1rem;
+  padding-right: 4.5rem;
   overflow-x: auto;
+  max-width: 100%;
+  box-sizing: border-box;
   font-size: 0.875rem;
   line-height: 1.5;
   font-family: ui-monospace, SFMono-Regular, "SF Mono", Consolas,
     "Liberation Mono", Menlo, monospace;
   background: transparent;
+  -webkit-overflow-scrolling: touch;
 }
 
 .ss-markdown-code-snippet code {
   background: transparent;
-  color: var(--search-text-color);
+  color: var(--search-markdown-code-block-color, var(--search-text-color));
   font-size: inherit;
   padding: 0;
   border: none;
@@ -1063,7 +1168,7 @@
   align-items: center;
   gap: 0.25rem;
   padding: 0.375rem 0.75rem;
-  background: rgba(255, 255, 255, 0.9);
+  background: var(--search-markdown-copy-btn-bg, rgba(255, 255, 255, 0.9));
   border: 1px solid var(--search-border-color);
   border-radius: 0.375rem;
   font-size: 0.75rem;
@@ -1080,8 +1185,11 @@
 }
 
 .ss-markdown-copy-button:hover {
-  background: white;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  background: var(--search-markdown-copy-btn-hover-bg, #ffffff);
+  box-shadow: var(
+    --search-markdown-copy-btn-shadow,
+    0 2px 8px rgba(0, 0, 0, 0.1)
+  );
 }
 
 .ss-markdown-copy-button .ss-markdown-check-icon {

--- a/packages/standalone/src/components/search-askai/styles.css
+++ b/packages/standalone/src/components/search-askai/styles.css
@@ -413,6 +413,68 @@
   border-radius: 0.5rem;
 }
 
+/* Thread depth errors: explicit colors so dark mode stays readable */
+.ssask-exp .ss-thread-depth-error-banner {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: #78350f;
+  background: #fffbeb;
+  border: 1px solid #fcd34d;
+}
+
+.ssask-exp.dark .ss-thread-depth-error-banner {
+  color: #fef9c3;
+  background: rgba(250, 204, 21, 0.12);
+  border-color: rgba(250, 204, 21, 0.45);
+}
+
+.ssask-exp .ss-thread-depth-error-link,
+.ssask-exp .ss-thread-depth-error-cta {
+  margin: 0;
+  padding: 0;
+  border: none;
+  font-size: inherit;
+  font-family: inherit;
+  line-height: inherit;
+  font-weight: 600;
+  color: var(--search-primary-color);
+  background: transparent;
+  vertical-align: baseline;
+}
+
+.ssask-exp .ss-thread-depth-error-link {
+  cursor: pointer;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+  -webkit-appearance: none;
+  appearance: none;
+  display: inline;
+}
+
+.ssask-exp .ss-thread-depth-error-cta {
+  display: inline;
+}
+
+.ssask-exp .ss-thread-depth-error-link:hover {
+  opacity: 0.92;
+}
+
+.ssask-exp .ss-thread-depth-error-link:focus-visible {
+  outline: 2px solid var(--search-primary-color);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+/* Ensure CTA stays visible on dark banner (higher contrast than body text) */
+.ssask-exp.dark .ss-thread-depth-error-banner .ss-thread-depth-error-link,
+.ssask-exp.dark .ss-thread-depth-error-banner .ss-thread-depth-error-cta {
+  color: #a5b4fc;
+}
+
 .ssask-exp .ss-qa-list {
   display: flex;
   flex-direction: column;

--- a/packages/standalone/src/components/sidepanel-askai/index.tsx
+++ b/packages/standalone/src/components/sidepanel-askai/index.tsx
@@ -1,0 +1,298 @@
+import { liteClient as algoliasearch } from "algoliasearch/lite";
+import type { FC } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useAskai } from "../search-askai/askai";
+import { ChatWidget, type Message } from "../search-askai/chat";
+import { ThreadDepthErrorBanner } from "../search-askai/error-utils";
+import {
+  AlgoliaLogo,
+  ChatSubmitIcon,
+  CloseIcon,
+  SparklesIcon,
+  SquarePenIcon,
+} from "../search-askai/icons";
+import { useSuggestedQuestions } from "../search-askai/use-suggested-questions";
+import useEffectiveDarkMode from "../search-askai/useEffectiveDarkMode";
+import "../search-askai/styles.css";
+import "./sidepanel.css";
+
+export interface SidepanelAskAIConfig {
+  applicationId: string;
+  apiKey: string;
+  indexName: string;
+  assistantId: string;
+  suggestedQuestionsEnabled?: boolean;
+  placeholder?: string;
+  buttonText?: string;
+  agentStudio?: boolean;
+  darkMode?: boolean;
+  triggerPosition?: "fixed" | "inline";
+}
+
+interface SidepanelInnerProps {
+  config: SidepanelAskAIConfig;
+  onClose: () => void;
+}
+
+const basePoweredByUrl =
+  "https://www.algolia.com/?utm_medium=website&utm_source=sitesearch&utm_campaign=poweredby";
+
+const SidepanelInner: FC<SidepanelInnerProps> = memo(function SidepanelInner({
+  config,
+  onClose,
+}) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [input, setInput] = useState("");
+
+  const poweredByHref = useMemo(
+    () =>
+      typeof window !== "undefined"
+        ? `${basePoweredByUrl}&utm_source=${encodeURIComponent(
+            window.location.hostname,
+          )}`
+        : basePoweredByUrl,
+    [],
+  );
+
+  const {
+    messages,
+    error,
+    isGenerating,
+    sendMessage,
+    startNewConversation,
+    threadDepthError,
+    showThreadDepthError,
+  } = useAskai({
+    applicationId: config.applicationId,
+    apiKey: config.apiKey,
+    indexName: config.indexName,
+    assistantId: config.assistantId,
+    agentStudio: config.agentStudio,
+  });
+
+  const suggestedQuestionsClient = useMemo(() => {
+    const client = algoliasearch(config.applicationId, config.apiKey);
+    client.addAlgoliaAgent("algolia-sitesearch");
+    return client;
+  }, [config.applicationId, config.apiKey]);
+
+  const suggestedQuestions = useSuggestedQuestions({
+    searchClient: suggestedQuestionsClient,
+    assistantId: config.assistantId,
+    suggestedQuestionsEnabled: config.suggestedQuestionsEnabled ?? false,
+    isOpen: true,
+  });
+
+  const handleSuggestedQuestionClick = useCallback(
+    (question: string) => {
+      const trimmed = question.trim();
+      if (!trimmed || isGenerating) return;
+      sendMessage({ text: trimmed });
+    },
+    [isGenerating, sendMessage],
+  );
+
+  const handleNewChat = useCallback(() => {
+    startNewConversation();
+    setInput("");
+    requestAnimationFrame(() => inputRef.current?.focus());
+  }, [startNewConversation]);
+
+  const placeholder = showThreadDepthError
+    ? "Conversation limit reached"
+    : isGenerating
+      ? "Answering..."
+      : (config.placeholder ?? "Ask AI anything");
+
+  const submit = useCallback(() => {
+    const trimmed = input.trim();
+    if (!trimmed || isGenerating || showThreadDepthError) return;
+    sendMessage({ text: trimmed });
+    setInput("");
+  }, [input, isGenerating, showThreadDepthError, sendMessage]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  useEffect(() => {
+    requestAnimationFrame(() => inputRef.current?.focus());
+  }, []);
+
+  return (
+    <div className="ss-sidepanel-inner">
+      <header className="ss-sidepanel-header">
+        <div className="ss-sidepanel-title-group">
+          <SparklesIcon
+            size={20}
+            gradientIdSuffix="-sp-hdr"
+            className="ss-sidepanel-title-sparkle"
+          />
+          <h2 className="ss-sidepanel-title">Ask AI</h2>
+        </div>
+        <div className="ss-sidepanel-header-actions">
+          <button
+            type="button"
+            className="ss-search-new-chat-button"
+            disabled={isGenerating && !showThreadDepthError}
+            title={
+              showThreadDepthError
+                ? "Start a new conversation"
+                : "New conversation"
+            }
+            aria-label={
+              showThreadDepthError
+                ? "Start a new conversation"
+                : "New conversation"
+            }
+            onClick={handleNewChat}
+          >
+            <SquarePenIcon size={18} />
+          </button>
+          <button
+            type="button"
+            className="ss-search-close-button"
+            onClick={onClose}
+            aria-label="Close panel"
+            title="Close"
+          >
+            <CloseIcon />
+          </button>
+        </div>
+      </header>
+
+      <div className="ss-sidepanel-body">
+        <ChatWidget
+          messages={messages as Message[]}
+          error={error as Error | null}
+          isGenerating={isGenerating}
+          applicationId={config.applicationId}
+          apiKey={config.apiKey}
+          assistantId={config.assistantId}
+          agentStudio={config.agentStudio}
+          suggestedQuestions={suggestedQuestions}
+          onSuggestedQuestionClick={handleSuggestedQuestionClick}
+          onNewChat={handleNewChat}
+          threadDepthError={threadDepthError}
+          showThreadDepthError={showThreadDepthError}
+          threadDepthBannerInChat={false}
+          showAiDisclaimer={false}
+          newestExchangeFirst={false}
+        />
+      </div>
+
+      <div className="ss-sidepanel-compose-stack">
+        {showThreadDepthError ? (
+          <div className="ss-sidepanel-thread-depth-banner">
+            <ThreadDepthErrorBanner onNewChat={handleNewChat} />
+          </div>
+        ) : null}
+        <footer className="ss-sidepanel-footer">
+          <search
+            className="ss-searchbox-form ss-searchbox-form--chat ss-sidepanel-compose-form"
+            onSubmit={(e) => {
+              e.preventDefault();
+              submit();
+            }}
+          >
+            <input
+              ref={inputRef}
+              autoComplete="off"
+              autoCorrect="off"
+              autoCapitalize="off"
+              spellCheck={false}
+              maxLength={512}
+              type="search"
+              placeholder={placeholder}
+              value={input}
+              disabled={isGenerating || showThreadDepthError}
+              onChange={(e) => setInput(e.currentTarget.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  submit();
+                }
+              }}
+            />
+            <button
+              type="submit"
+              className="ss-search-submit-chat-button"
+              disabled={isGenerating || showThreadDepthError || !input.trim()}
+              title="Send message"
+              aria-label="Send message"
+            >
+              <ChatSubmitIcon size={22} />
+            </button>
+          </search>
+          <div className="ss-sidepanel-ai-notice">
+            <p className="ss-sidepanel-ai-notice-text">
+              Answers are generated with AI which can make mistakes.
+            </p>
+          </div>
+          <div className="ss-sidepanel-powered-by">
+            <a
+              className="ss-sidepanel-powered-by-link"
+              href={poweredByHref}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <span className="ss-sidepanel-powered-by-label">Powered by </span>
+              <AlgoliaLogo size={80} />
+            </a>
+          </div>
+        </footer>
+      </div>
+    </div>
+  );
+});
+
+export default function SidepanelAskAIExperience(config: SidepanelAskAIConfig) {
+  const [open, setOpen] = useState(false);
+  const isDark = useEffectiveDarkMode(config.darkMode);
+  const triggerPosition = config.triggerPosition ?? "fixed";
+
+  return (
+    <div
+      className={`ssask-exp ss-sidepanel-root ss-sidepanel-root--${triggerPosition}${isDark ? " dark" : ""}`}
+    >
+      <button
+        type="button"
+        className="ss-sidepanel-trigger"
+        onClick={() => setOpen(true)}
+        aria-expanded={open}
+        aria-haspopup="dialog"
+      >
+        <SparklesIcon size={18} />
+        <span>{config.buttonText ?? "Ask AI"}</span>
+      </button>
+      {open &&
+        typeof document !== "undefined" &&
+        createPortal(
+          <>
+            <button
+              type="button"
+              className="ss-sidepanel-backdrop"
+              aria-label="Close panel"
+              onClick={() => setOpen(false)}
+            />
+            <div
+              className={`ss-sidepanel-panel ssask-exp${isDark ? " dark" : ""}`}
+              role="dialog"
+              aria-modal="true"
+            >
+              <SidepanelInner config={config} onClose={() => setOpen(false)} />
+            </div>
+          </>,
+          document.body,
+        )}
+    </div>
+  );
+}

--- a/packages/standalone/src/components/sidepanel-askai/index.tsx
+++ b/packages/standalone/src/components/sidepanel-askai/index.tsx
@@ -4,7 +4,10 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useAskai } from "../search-askai/askai";
 import { ChatWidget, type Message } from "../search-askai/chat";
-import { ThreadDepthErrorBanner } from "../search-askai/error-utils";
+import {
+  ThreadDepthErrorBanner,
+  threadDepthErrorDetail,
+} from "../search-askai/error-utils";
 import {
   AlgoliaLogo,
   ChatSubmitIcon,
@@ -61,7 +64,6 @@ const SidepanelInner: FC<SidepanelInnerProps> = memo(function SidepanelInner({
     isGenerating,
     sendMessage,
     startNewConversation,
-    threadDepthError,
     showThreadDepthError,
   } = useAskai({
     applicationId: config.applicationId,
@@ -181,7 +183,6 @@ const SidepanelInner: FC<SidepanelInnerProps> = memo(function SidepanelInner({
           suggestedQuestions={suggestedQuestions}
           onSuggestedQuestionClick={handleSuggestedQuestionClick}
           onNewChat={handleNewChat}
-          threadDepthError={threadDepthError}
           showThreadDepthError={showThreadDepthError}
           threadDepthBannerInChat={false}
           showAiDisclaimer={false}
@@ -192,7 +193,10 @@ const SidepanelInner: FC<SidepanelInnerProps> = memo(function SidepanelInner({
       <div className="ss-sidepanel-compose-stack">
         {showThreadDepthError ? (
           <div className="ss-sidepanel-thread-depth-banner">
-            <ThreadDepthErrorBanner onNewChat={handleNewChat} />
+            <ThreadDepthErrorBanner
+              onNewChat={handleNewChat}
+              detailMessage={threadDepthErrorDetail(error)}
+            />
           </div>
         ) : null}
         <footer className="ss-sidepanel-footer">

--- a/packages/standalone/src/components/sidepanel-askai/sidepanel.css
+++ b/packages/standalone/src/components/sidepanel-askai/sidepanel.css
@@ -1,0 +1,250 @@
+/* Sidepanel shell (ChatWidget styles come from search-askai/styles.css via .ssask-exp) */
+
+.ss-sidepanel-root {
+  position: relative;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* Inline trigger: needs a full-width positioning context or the button hugs a collapsed box */
+.ss-sidepanel-root--inline {
+  min-height: 88px;
+  width: 100%;
+}
+
+.ss-sidepanel-trigger {
+  position: fixed;
+  right: 1.25rem;
+  bottom: 1.25rem;
+  z-index: 2147483640;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.65rem 1rem;
+  border: 1px solid var(--search-border-color, #d6d6e7);
+  border-radius: var(--search-border-radius, 0.5rem);
+  background: var(--search-neutral-color, #fff);
+  color: var(--search-text-color, #23263b);
+  font-size: var(--search-button-font-size, 0.9rem);
+  font-weight: 500;
+  cursor: pointer;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.12);
+  transition: var(--search-button-transition, all 0.2s ease);
+}
+
+.ss-sidepanel-trigger:hover {
+  background: var(--search-hover-color, #dde3f9);
+  transform: translateY(-1px);
+}
+
+.ss-sidepanel-trigger svg {
+  flex-shrink: 0;
+}
+
+/* Inline trigger: override fixed positioning (must follow base .ss-sidepanel-trigger for specificity order) */
+.ss-sidepanel-root--inline .ss-sidepanel-trigger {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  z-index: 1;
+}
+
+.ss-sidepanel-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 2147483641;
+  margin: 0;
+  padding: 0;
+  border: none;
+  cursor: pointer;
+  background: rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+.ss-sidepanel-panel {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 2147483642;
+  display: flex;
+  flex-direction: column;
+  width: min(420px, calc(100vw - 2rem));
+  max-width: 100%;
+  max-height: calc(100vh - 2rem);
+  border-radius: var(--search-modal-border-radius, 0.75rem);
+  overflow: hidden;
+  background: var(--search-background-color, #f5f5fa);
+  box-shadow:
+    var(--search-modal-shadow, 0 25px 50px -12px rgba(0, 0, 0, 0.25)),
+    0 0 0 1px rgba(15, 23, 42, 0.06);
+}
+
+.ss-sidepanel-inner {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  min-width: 0;
+}
+
+.ss-sidepanel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--search-border-color, #d6d6e7);
+  background: var(--search-neutral-color, #fff);
+  flex-shrink: 0;
+}
+
+.ss-sidepanel-title-group {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  min-width: 0;
+}
+
+.ss-sidepanel-title-sparkle {
+  flex-shrink: 0;
+  display: block;
+}
+
+.ss-sidepanel-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--search-text-color, #23263b);
+}
+
+.ss-sidepanel-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.ss-sidepanel-body {
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  /* Match panel theme (avoids see-through gaps resolving to document-level vars) */
+  background: var(--search-background-color);
+}
+
+/*
+ * Search modal caps chat at 50vh — sidepanel is full-height; fill the body and remove the cap
+ * so we do not get a large empty band (often light) under the welcome state.
+ */
+.ssask-exp .ss-sidepanel-body .ss-chat-root {
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
+  max-height: none;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+/* Footer stack: rule above composer separates chat scroll from input (matches classic layout). */
+.ss-sidepanel-compose-stack {
+  flex-shrink: 0;
+  border-top: 1px solid var(--search-border-color, #d6d6e7);
+  background: var(--search-background-color);
+}
+
+.ss-sidepanel-thread-depth-banner {
+  padding: 0.5rem 1rem 0.25rem;
+}
+
+.ss-sidepanel-footer {
+  flex-shrink: 0;
+  padding: 0.5rem 1rem 1rem;
+  border-top: none;
+  background: var(--search-background-color);
+}
+
+.ss-sidepanel-ai-notice {
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-start;
+  margin-top: 0.5rem;
+}
+
+.ss-sidepanel-ai-notice-text {
+  margin: 0;
+  max-width: none;
+  width: 100%;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  text-align: left;
+  color: var(--search-subtle-text-color, #64748b);
+}
+
+.ss-sidepanel-powered-by {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  margin-top: 0.5rem;
+}
+
+.ss-sidepanel-powered-by-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  color: var(--search-subtle-text-color, #64748b);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.ss-sidepanel-powered-by-link:hover {
+  color: var(--search-primary-color, #003dff);
+}
+
+.ss-sidepanel-panel.ssask-exp.dark .ss-sidepanel-ai-notice-text,
+.ss-sidepanel-panel.ssask-exp.dark .ss-sidepanel-powered-by-link {
+  color: var(--search-secondary-color, #9aa1b2);
+}
+
+.ss-sidepanel-powered-by-label {
+  white-space: nowrap;
+}
+
+@media (max-width: 480px) {
+  .ss-sidepanel-powered-by-label {
+    display: none;
+  }
+}
+
+.ss-sidepanel-footer search {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+}
+
+.ss-sidepanel-footer .ss-searchbox-form {
+  width: 100%;
+}
+
+/* Match search-askai composer: bordered field uses footer padding, not extra outer margin. */
+.ss-sidepanel-footer .ss-searchbox-form.ss-searchbox-form--chat {
+  margin: 0;
+  width: 100%;
+  box-sizing: border-box;
+  /* Slightly tighter than modal composer so the field sits higher in the footer stack. */
+  padding: 0.35rem 0.5rem;
+}
+
+@media (max-width: 480px) {
+  .ss-sidepanel-panel {
+    top: 0.75rem;
+    right: 0.75rem;
+    bottom: 0.75rem;
+    width: min(420px, calc(100vw - 1.5rem));
+    max-height: calc(100vh - 1.5rem);
+  }
+}

--- a/packages/standalone/src/index.ts
+++ b/packages/standalone/src/index.ts
@@ -6,5 +6,9 @@ export { default as Search } from "./components/search/index";
 export type { SearchWithAskAIConfig } from "./components/search-askai/index";
 export { default as SearchWithAskAI } from "./components/search-askai/index";
 
+// Sidepanel Ask AI (vanilla UMD: SiteSearchSidepanelAskAI)
+export type { SidepanelAskAIConfig } from "./components/sidepanel-askai/index";
+export { default as SidepanelAskAI } from "./components/sidepanel-askai/index";
+
 // Shared types
 export type { HitsAttributesMapping } from "./components/types";

--- a/packages/standalone/src/vanilla/resolve-container-element.ts
+++ b/packages/standalone/src/vanilla/resolve-container-element.ts
@@ -1,0 +1,20 @@
+/**
+ * Resolves the vanilla widget mount node. String `container` must be an id selector (`#my-root`);
+ * we use {@link Document.getElementById} instead of `querySelector` so the value is treated as an
+ * id token, not arbitrary selector/HTML text.
+ */
+const ID_SELECTOR = /^#[^#\s]+$/;
+
+export function resolveContainerElement(
+  container: string | HTMLElement,
+): HTMLElement | null {
+  if (typeof container !== "string") {
+    return container;
+  }
+  if (!ID_SELECTOR.test(container)) {
+    throw new Error(
+      'SiteSearch: container must be an HTMLElement or an id selector (e.g. "#search-root").',
+    );
+  }
+  return document.getElementById(container.slice(1));
+}

--- a/packages/standalone/src/vanilla/search-askai.tsx
+++ b/packages/standalone/src/vanilla/search-askai.tsx
@@ -2,30 +2,25 @@ import { h, render } from "preact";
 import SearchWithAskAI, {
   type SearchWithAskAIConfig,
 } from "../components/search-askai";
+import { resolveContainerElement } from "./resolve-container-element";
 
 type InitOptions = SearchWithAskAIConfig & { container: string | HTMLElement };
 const instances = new Map<HTMLElement, true>();
 
 export function init({ container, ...config }: InitOptions): void {
-  const el =
-    typeof container === "string"
-      ? (document.querySelector(container) as HTMLElement | null)
-      : (container as HTMLElement | null);
-  if (!el) {
+  const containerElement = resolveContainerElement(container);
+  if (!containerElement) {
     throw new Error("Container not found");
   }
-  render(h(SearchWithAskAI, { ...config }), el);
-  instances.set(el, true);
+  render(h(SearchWithAskAI, { ...config }), containerElement);
+  instances.set(containerElement, true);
 }
 
 export function destroy(container: string | HTMLElement): void {
-  const el =
-    typeof container === "string"
-      ? (document.querySelector(container) as HTMLElement | null)
-      : (container as HTMLElement | null);
-  if (!el) return;
-  render(null, el);
-  instances.delete(el);
+  const containerElement = resolveContainerElement(container);
+  if (!containerElement) return;
+  render(null, containerElement);
+  instances.delete(containerElement);
 }
 
 export default { init, destroy };

--- a/packages/standalone/src/vanilla/sidepanel-askai.tsx
+++ b/packages/standalone/src/vanilla/sidepanel-askai.tsx
@@ -1,24 +1,23 @@
 import { h, render } from "preact";
-import SearchExperience, { type SearchConfig } from "../components/search";
+import SidepanelAskAIExperience, {
+  type SidepanelAskAIConfig,
+} from "../components/sidepanel-askai";
 import { resolveContainerElement } from "./resolve-container-element";
 
-type InitOptions = SearchConfig & { container: string | HTMLElement };
-const instances = new Map<HTMLElement, true>();
+type InitOptions = SidepanelAskAIConfig & { container: string | HTMLElement };
 
 export function init({ container, ...config }: InitOptions): void {
   const containerElement = resolveContainerElement(container);
   if (!containerElement) {
     throw new Error("Container not found");
   }
-  render(h(SearchExperience, { ...config }), containerElement);
-  instances.set(containerElement, true);
+  render(h(SidepanelAskAIExperience, { ...config }), containerElement);
 }
 
 export function destroy(container: string | HTMLElement): void {
   const containerElement = resolveContainerElement(container);
   if (!containerElement) return;
   render(null, containerElement);
-  instances.delete(containerElement);
 }
 
 export default { init, destroy };


### PR DESCRIPTION
## 🤔 What
Improves Ask AI in @algolia/sitesearch:
- new sidepanel experience,
- Agent Studio / thread-depth handling, and chat + markdown polish.
- Docs registry hooks and the vanilla demo are updated to match.

## How 🧐

- Ask AI core: thread-depth / Agent Studio–related behavior and messaging (see askai.ts, error-utils.tsx, index.tsx, search-input.tsx).
- Sidepanel Ask AI: new entry (sidepanel-askai), portal + floating panel shell, footer aligned with docsearch-style AI disclaimer and Powered by Algolia.
- ChatWidget: optional showAiDisclaimer / newestExchangeFirst; chronological order for sidepanel with stick-to-bottom scroll when appropriate.
- Markdown / code: theme tokens for dark-mode code blocks and inline code; horizontal overflow fixes (flex min-width: 0, constrained snippets, pre scroll).
- Vanilla: sidepanel-askai init, shared resolve-container-element helper; search/search-askai init aligned.

## 🧪 How to test

1. On Ask AI, hit thread-depth limit → see error + start new conversation; confirm the next turn uses a new API thread, not the capped one.
2. In the modal, send several follow-ups (Enter) → same conversation until you explicitly start new or leave Ask AI.
3. Sidepanel: open vanilla demo (or your integration), dark + light, long code blocks, new vs old messages order.


## 📸 Screenshots
<img width="1728" height="963" alt="image" src="https://github.com/user-attachments/assets/09da95e6-50b1-49ef-beb2-856b9fc74fa7" />

<img width="453" height="966" alt="image" src="https://github.com/user-attachments/assets/072b51cc-b48a-4a83-8051-d9ef4668b487" />

