### PR TITLE
fix(playground): unrecognized chars crash

### DIFF
--- a/apps/docs/src/registry/experiences/search-askai/components/search-ai.tsx
+++ b/apps/docs/src/registry/experiences/search-askai/components/search-ai.tsx
@@ -854,7 +854,10 @@ const ChatWidget = memo(function ChatWidget({
                                     <mark className="bg-transparent text-muted-foreground underline decoration-1 underline-offset-4">
                                       &quot;{part.output?.query}&quot;
                                     </mark>{" "}
-                                    found {part.output?.hits.length || "no"}{" "}
+                                    found{" "}
+                                    {Array.isArray(part.output?.hits)
+                                      ? part.output.hits.length
+                                      : "no"}{" "}
                                     results
                                   </span>
                                 </p>

--- a/apps/docs/src/registry/experiences/sidepanel-askai/components/sidepanel-askai.tsx
+++ b/apps/docs/src/registry/experiences/sidepanel-askai/components/sidepanel-askai.tsx
@@ -155,7 +155,7 @@ function extractLinksFromMessage(message: Message | null): ExtractedLink[] {
       return;
     }
 
-    if (part.text.length === 0) {
+    if (typeof part.text !== "string" || part.text.length === 0) {
       return;
     }
 
@@ -796,7 +796,10 @@ const ChatWidget = memo(function ChatWidget({
                                     <mark className="bg-transparent text-muted-foreground underline decoration-1 underline-offset-4">
                                       &quot;{part.output?.query}&quot;
                                     </mark>{" "}
-                                    found {part.output?.hits.length || "no"}{" "}
+                                    found{" "}
+                                    {Array.isArray(part.output?.hits)
+                                      ? part.output.hits.length
+                                      : "no"}{" "}
                                     results
                                   </span>
                                 </p>

--- a/packages/standalone/src/components/search-askai/chat.tsx
+++ b/packages/standalone/src/components/search-askai/chat.tsx
@@ -304,7 +304,9 @@ export const ChatWidget = memo(function ChatWidget({
                   {exchange.userMessage.parts.map((part, index) =>
                     part.type === "text" ? (
                       // biome-ignore lint/suspicious/noArrayIndexKey: better
-                      <span key={index}>{part.text}</span>
+                      <span key={index}>
+                        {typeof part.text === "string" ? part.text : ""}
+                      </span>
                     ) : null,
                   )}
                 </div>
@@ -320,10 +322,12 @@ export const ChatWidget = memo(function ChatWidget({
                           return <p key={`${index}`}>{part}</p>;
                         }
                         if (part.type === "text") {
+                          const text =
+                            typeof part.text === "string" ? part.text : "";
                           return (
                             // biome-ignore lint/suspicious/noArrayIndexKey: better
                             <MemoizedMarkdown key={`${index}`}>
-                              {part.text}
+                              {text}
                             </MemoizedMarkdown>
                           );
                         } else if (
@@ -371,7 +375,10 @@ export const ChatWidget = memo(function ChatWidget({
                                 <span>
                                   Searched for{" "}
                                   <mark>&quot;{part.output?.query}&quot;</mark>{" "}
-                                  found {part.output?.hits.length || "no"}{" "}
+                                  found{" "}
+                                  {Array.isArray(part.output?.hits)
+                                    ? part.output.hits.length
+                                    : "no"}{" "}
                                   results
                                 </span>
                               </p>
@@ -459,7 +466,9 @@ export const ChatWidget = memo(function ChatWidget({
                     const parts = exchange.assistantMessage?.parts ?? [];
                     const textContent = parts
                       .flatMap((part) =>
-                        part.type === "text" ? [part.text] : [],
+                        part.type === "text" && typeof part.text === "string"
+                          ? [part.text]
+                          : [],
                       )
                       .join("")
                       .trim();

--- a/packages/standalone/src/components/search-askai/markdown.tsx
+++ b/packages/standalone/src/components/search-askai/markdown.tsx
@@ -6,9 +6,31 @@ interface MemoizedMarkdownProps {
   className?: string;
 }
 
+/** Replace unpaired UTF-16 surrogates (common in crawled index text). */
+function replaceUnpairedSurrogates(value: string): string {
+  return value.replace(
+    /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g,
+    "\uFFFD",
+  );
+}
+
+function toMarkdownString(value: unknown): string {
+  if (typeof value !== "string") return "";
+  return replaceUnpairedSurrogates(value);
+}
+
+function safeEncodeURIComponent(value: string): string {
+  const sanitized = replaceUnpairedSurrogates(value);
+  try {
+    return encodeURIComponent(sanitized);
+  } catch {
+    return "";
+  }
+}
+
 // Escape HTML special characters for safe insertion
 function escapeHtml(html: string): string {
-  return html
+  return toMarkdownString(html)
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
@@ -23,7 +45,7 @@ const renderer = new marked.Renderer();
 renderer.code = ({ text, lang = "", escaped }: Tokens.Code): string => {
   const languageClass = lang ? `language-${lang}` : "";
   const safeCode = escaped ? text : escapeHtml(text);
-  const encodedCode = encodeURIComponent(text);
+  const encodedCode = safeEncodeURIComponent(text);
 
   const copyIconSvg = `
     <svg class="ss-markdown-copy-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -65,15 +87,16 @@ export const MemoizedMarkdown = memo(function MemoizedMarkdown({
   const containerRef = useRef<HTMLDivElement>(null);
 
   const html = useMemo(() => {
+    const source = toMarkdownString(children);
     try {
-      return marked(children, {
+      return marked(source, {
         renderer,
         breaks: true,
         gfm: true,
       });
     } catch (error) {
       console.error("Error parsing markdown:", error);
-      return escapeHtml(children);
+      return escapeHtml(source);
     }
   }, [children]);
 


### PR DESCRIPTION
## Summary

Fixes AskAI white-screen crash after responses when index data contains invalid Unicode or when the search tool returns a non-array hits value.

- Guard part.output?.hits with Array.isArray() before reading .length (fixes TypeError in chat tool status)
- Harden markdown rendering: strip unpaired UTF-16 surrogates and use safe encodeURIComponent for code-block copy buttons
- Validate part.text is a string before rendering or copying