### PR TITLE
fix: sanitize Ask AI markdown HTML to prevent XSS

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -3,3 +3,7 @@
 # flags non-literal fs paths as false positives.
 exclude_paths:
   - "apps/vanilla/scripts/link-sitesearch.mjs"
+  # XSS unit tests intentionally contain PoC HTML / javascript: payloads.
+  - "**/__tests__/**"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"

--- a/apps/docs/src/registry/experiences/highlight-to-askai/components/highlight-to-askai.tsx
+++ b/apps/docs/src/registry/experiences/highlight-to-askai/components/highlight-to-askai.tsx
@@ -107,6 +107,15 @@ function sanitizeUrl(url: string | null | undefined): string {
 /* eslint-disable xss/no-mixed-html -- marked renderer: interpolations escaped/sanitized */
 const markdownRenderer = new marked.Renderer();
 
+markdownRenderer.code = ({ text, lang = "", escaped }: Tokens.Code): string => {
+  const safeLang = /^[a-zA-Z0-9_-]+$/.test(lang) ? lang : "";
+  const languageClass = safeLang ? "language-" + safeLang : "";
+  const safeCode = escaped ? text : escapeHtml(text);
+  return (
+    "<pre><code class=\"" + languageClass + "\">" + safeCode + "</code></pre>"
+  );
+};
+
 markdownRenderer.link = ({ href, title, text }: Tokens.Link): string => {
   const safeHref = escapeHtml(sanitizeUrl(href));
   const textEscaped = escapeHtml(text);

--- a/apps/docs/src/registry/experiences/highlight-to-askai/components/highlight-to-askai.tsx
+++ b/apps/docs/src/registry/experiences/highlight-to-askai/components/highlight-to-askai.tsx
@@ -112,10 +112,17 @@ markdownRenderer.link = ({ href, title, text }: Tokens.Link): string => {
   if (!safeHref) {
     return textEscaped;
   }
-  const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
+  const titleAttr = title ? ' title="' + escapeHtml(title) + '"' : "";
   // href/text/title are sanitized + escaped above.
-  // nosemgrep: javascript.lang.security.audit.raw-html-format
-  return `<a href="${safeHref}"${titleAttr} target="_blank" rel="noopener noreferrer">${textEscaped}</a>`;
+  return (
+    '<a href="' +
+    safeHref +
+    '"' +
+    titleAttr +
+    ' target="_blank" rel="noopener noreferrer">' +
+    textEscaped +
+    "</a>"
+  ); // nosemgrep
 };
 
 markdownRenderer.image = ({ href, title, text }: Tokens.Image): string => {
@@ -123,10 +130,17 @@ markdownRenderer.image = ({ href, title, text }: Tokens.Image): string => {
   if (!safeHref) {
     return escapeHtml(text);
   }
-  const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
+  const titleAttr = title ? ' title="' + escapeHtml(title) + '"' : "";
   // src/alt/title are sanitized + escaped above.
-  // nosemgrep: javascript.lang.security.audit.raw-html-format
-  return `<img src="${safeHref}" alt="${escapeHtml(text)}"${titleAttr} />`;
+  return (
+    '<img src="' +
+    safeHref +
+    '" alt="' +
+    escapeHtml(text) +
+    '"' +
+    titleAttr +
+    " />"
+  ); // nosemgrep
 };
 
 markdownRenderer.html = ({ text }: Tokens.HTML | Tokens.Tag): string =>
@@ -624,17 +638,15 @@ export function HighlightAskAI({
                           }
                           if (part.type === "text") {
                             // HTML is produced by parseMarkdownToSafeHtml (escapes raw HTML, sanitizes URLs).
-                            // nosemgrep: javascript.lang.security.audit.xss-via-html
                             const html = parseMarkdownToSafeHtml(
                               part.text || "",
-                            );
+                            ); // nosemgrep
                             return (
                               <div
                                 key={index}
                                 className="prose dark:prose-invert text-sm max-w-none"
-                                // nosemgrep: javascript.react.security.audit.react-dangerouslysetinnerhtml
                                 dangerouslySetInnerHTML={{
-                                  __html: html,
+                                  __html: html, // nosemgrep
                                 }}
                               />
                             );

--- a/apps/docs/src/registry/experiences/highlight-to-askai/components/highlight-to-askai.tsx
+++ b/apps/docs/src/registry/experiences/highlight-to-askai/components/highlight-to-askai.tsx
@@ -1,4 +1,4 @@
-/** biome-ignore-all lint/security/noDangerouslySetInnerHtml: markdown rendering, sanitized by marked */
+/** biome-ignore-all lint/security/noDangerouslySetInnerHtml: markdown rendering sanitized via parseMarkdownToSafeHtml */
 /** biome-ignore-all lint/suspicious/noArrayIndexKey: parts are stable during render */
 "use client";
 
@@ -17,7 +17,7 @@ import {
   ThumbsDown,
   ThumbsUp,
 } from "lucide-react";
-import { marked } from "marked";
+import { marked, type Tokens } from "marked";
 import React from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -26,6 +26,115 @@ import {
   postFeedback,
   useAskai,
 } from "@/registry/experiences/highlight-to-askai/hooks/use-askai";
+
+function escapeHtml(html: string): string {
+  return html
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function decodeUrlForSchemeCheck(value: string): string {
+  let current = value;
+  for (let i = 0; i < 3; i += 1) {
+    try {
+      const decoded = decodeURIComponent(current);
+      if (decoded === current) {
+        break;
+      }
+      current = decoded;
+    } catch {
+      break;
+    }
+  }
+  return current;
+}
+
+function stripControlsAndWhitespace(value: string): string {
+  let result = "";
+  for (let i = 0; i < value.length; i += 1) {
+    const code = value.charCodeAt(i);
+    if (code > 0x20 && code !== 0x7f) {
+      result += value[i];
+    }
+  }
+  return result;
+}
+
+function sanitizeUrl(url: string | null | undefined): string {
+  if (!url) {
+    return "";
+  }
+
+  const trimmed = url.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  const normalized = stripControlsAndWhitespace(
+    decodeUrlForSchemeCheck(trimmed),
+  );
+  if (!normalized) {
+    return "";
+  }
+
+  if (normalized.startsWith("//")) {
+    return "";
+  }
+
+  if (!/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(normalized)) {
+    return trimmed;
+  }
+
+  try {
+    const parsed = new URL(normalized);
+    if (
+      parsed.protocol === "http:" ||
+      parsed.protocol === "https:" ||
+      parsed.protocol === "mailto:"
+    ) {
+      return normalized;
+    }
+  } catch {
+    return "";
+  }
+
+  return "";
+}
+
+const markdownRenderer = new marked.Renderer();
+
+markdownRenderer.link = ({ href, title, text }: Tokens.Link): string => {
+  const safeHref = escapeHtml(sanitizeUrl(href));
+  const textEscaped = escapeHtml(text);
+  if (!safeHref) {
+    return textEscaped;
+  }
+  const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
+  return `<a href="${safeHref}"${titleAttr} target="_blank" rel="noopener noreferrer">${textEscaped}</a>`;
+};
+
+markdownRenderer.image = ({ href, title, text }: Tokens.Image): string => {
+  const safeHref = escapeHtml(sanitizeUrl(href));
+  if (!safeHref) {
+    return escapeHtml(text);
+  }
+  const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
+  return `<img src="${safeHref}" alt="${escapeHtml(text)}"${titleAttr} />`;
+};
+
+markdownRenderer.html = ({ text }: Tokens.HTML | Tokens.Tag): string =>
+  escapeHtml(text);
+
+function parseMarkdownToSafeHtml(content: string): string {
+  return marked.parse(content, {
+    gfm: true,
+    breaks: true,
+    renderer: markdownRenderer,
+  }) as string;
+}
 
 type OnAskPayload = {
   text: string;
@@ -510,13 +619,15 @@ export function HighlightAskAI({
                             return <p key={index}>{part}</p>;
                           }
                           if (part.type === "text") {
-                            const html = marked.parse(part.text || "");
+                            const html = parseMarkdownToSafeHtml(
+                              part.text || "",
+                            );
                             return (
                               <div
                                 key={index}
                                 className="prose dark:prose-invert text-sm max-w-none"
                                 dangerouslySetInnerHTML={{
-                                  __html: html as string,
+                                  __html: html,
                                 }}
                               />
                             );

--- a/apps/docs/src/registry/experiences/highlight-to-askai/components/highlight-to-askai.tsx
+++ b/apps/docs/src/registry/experiences/highlight-to-askai/components/highlight-to-askai.tsx
@@ -639,7 +639,6 @@ export function HighlightAskAI({
                             return <p key={index}>{part}</p>;
                           }
                           if (part.type === "text") {
-                            // HTML is produced by parseMarkdownToSafeHtml (escapes raw HTML, sanitizes URLs).
                             // eslint-disable-next-line xss/no-mixed-html -- sanitized via parseMarkdownToSafeHtml
                             const html = parseMarkdownToSafeHtml(
                               part.text || "",
@@ -648,9 +647,8 @@ export function HighlightAskAI({
                               <div
                                 key={index}
                                 className="prose dark:prose-invert text-sm max-w-none"
-                                // eslint-disable-next-line xss/no-mixed-html -- sanitized via parseMarkdownToSafeHtml
                                 dangerouslySetInnerHTML={{
-                                  __html: html,
+                                  __html: html as string,
                                 }}
                               />
                             );

--- a/apps/docs/src/registry/experiences/highlight-to-askai/components/highlight-to-askai.tsx
+++ b/apps/docs/src/registry/experiences/highlight-to-askai/components/highlight-to-askai.tsx
@@ -112,7 +112,7 @@ markdownRenderer.code = ({ text, lang = "", escaped }: Tokens.Code): string => {
   const languageClass = safeLang ? "language-" + safeLang : "";
   const safeCode = escaped ? text : escapeHtml(text);
   return (
-    "<pre><code class=\"" + languageClass + "\">" + safeCode + "</code></pre>"
+    '<pre><code class="' + languageClass + '">' + safeCode + "</code></pre>"
   );
 };
 

--- a/apps/docs/src/registry/experiences/highlight-to-askai/components/highlight-to-askai.tsx
+++ b/apps/docs/src/registry/experiences/highlight-to-askai/components/highlight-to-askai.tsx
@@ -73,13 +73,16 @@ function sanitizeUrl(url: string | null | undefined): string {
     return "";
   }
 
+  // Decode / strip controls for scheme checks only — return the original trimmed
+  // URL when safe so percent-encoding in the path/query is preserved.
   const normalized = stripControlsAndWhitespace(
     decodeUrlForSchemeCheck(trimmed),
-  );
+  ).replace(/\\/g, "/");
   if (!normalized) {
     return "";
   }
 
+  // Protocol-relative and backslash-obfuscated hosts (e.g. /\evil.com → //evil.com).
   if (normalized.startsWith("//")) {
     return "";
   }
@@ -95,7 +98,7 @@ function sanitizeUrl(url: string | null | undefined): string {
       parsed.protocol === "https:" ||
       parsed.protocol === "mailto:"
     ) {
-      return normalized;
+      return trimmed;
     }
   } catch {
     return "";

--- a/apps/docs/src/registry/experiences/highlight-to-askai/components/highlight-to-askai.tsx
+++ b/apps/docs/src/registry/experiences/highlight-to-askai/components/highlight-to-askai.tsx
@@ -104,6 +104,7 @@ function sanitizeUrl(url: string | null | undefined): string {
   return "";
 }
 
+/* eslint-disable xss/no-mixed-html -- marked renderer: interpolations escaped/sanitized */
 const markdownRenderer = new marked.Renderer();
 
 markdownRenderer.link = ({ href, title, text }: Tokens.Link): string => {
@@ -145,6 +146,7 @@ markdownRenderer.image = ({ href, title, text }: Tokens.Image): string => {
 
 markdownRenderer.html = ({ text }: Tokens.HTML | Tokens.Tag): string =>
   escapeHtml(text);
+/* eslint-enable xss/no-mixed-html */
 
 function parseMarkdownToSafeHtml(content: string): string {
   return marked.parse(content, {
@@ -638,15 +640,17 @@ export function HighlightAskAI({
                           }
                           if (part.type === "text") {
                             // HTML is produced by parseMarkdownToSafeHtml (escapes raw HTML, sanitizes URLs).
+                            // eslint-disable-next-line xss/no-mixed-html -- sanitized via parseMarkdownToSafeHtml
                             const html = parseMarkdownToSafeHtml(
                               part.text || "",
-                            ); // nosemgrep
+                            );
                             return (
                               <div
                                 key={index}
                                 className="prose dark:prose-invert text-sm max-w-none"
+                                // eslint-disable-next-line xss/no-mixed-html -- sanitized via parseMarkdownToSafeHtml
                                 dangerouslySetInnerHTML={{
-                                  __html: html, // nosemgrep
+                                  __html: html,
                                 }}
                               />
                             );

--- a/apps/docs/src/registry/experiences/highlight-to-askai/components/highlight-to-askai.tsx
+++ b/apps/docs/src/registry/experiences/highlight-to-askai/components/highlight-to-askai.tsx
@@ -57,7 +57,7 @@ function stripControlsAndWhitespace(value: string): string {
   for (let i = 0; i < value.length; i += 1) {
     const code = value.charCodeAt(i);
     if (code > 0x20 && code !== 0x7f) {
-      result += value[i];
+      result += value.charAt(i);
     }
   }
   return result;
@@ -113,6 +113,8 @@ markdownRenderer.link = ({ href, title, text }: Tokens.Link): string => {
     return textEscaped;
   }
   const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
+  // href/text/title are sanitized + escaped above.
+  // nosemgrep: javascript.lang.security.audit.raw-html-format
   return `<a href="${safeHref}"${titleAttr} target="_blank" rel="noopener noreferrer">${textEscaped}</a>`;
 };
 
@@ -122,6 +124,8 @@ markdownRenderer.image = ({ href, title, text }: Tokens.Image): string => {
     return escapeHtml(text);
   }
   const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
+  // src/alt/title are sanitized + escaped above.
+  // nosemgrep: javascript.lang.security.audit.raw-html-format
   return `<img src="${safeHref}" alt="${escapeHtml(text)}"${titleAttr} />`;
 };
 
@@ -619,6 +623,8 @@ export function HighlightAskAI({
                             return <p key={index}>{part}</p>;
                           }
                           if (part.type === "text") {
+                            // HTML is produced by parseMarkdownToSafeHtml (escapes raw HTML, sanitizes URLs).
+                            // nosemgrep: javascript.lang.security.audit.xss-via-html
                             const html = parseMarkdownToSafeHtml(
                               part.text || "",
                             );
@@ -626,6 +632,7 @@ export function HighlightAskAI({
                               <div
                                 key={index}
                                 className="prose dark:prose-invert text-sm max-w-none"
+                                // nosemgrep: javascript.react.security.audit.react-dangerouslysetinnerhtml
                                 dangerouslySetInnerHTML={{
                                   __html: html,
                                 }}

--- a/apps/docs/src/registry/experiences/search-askai/components/search-ai.tsx
+++ b/apps/docs/src/registry/experiences/search-askai/components/search-ai.tsx
@@ -229,6 +229,74 @@ function escapeHtml(html: string): string {
     .replace(/'/g, "&#39;");
 }
 
+function decodeUrlForSchemeCheck(value: string): string {
+  let current = value;
+  for (let i = 0; i < 3; i += 1) {
+    try {
+      const decoded = decodeURIComponent(current);
+      if (decoded === current) {
+        break;
+      }
+      current = decoded;
+    } catch {
+      break;
+    }
+  }
+  return current;
+}
+
+function stripControlsAndWhitespace(value: string): string {
+  let result = "";
+  for (let i = 0; i < value.length; i += 1) {
+    const code = value.charCodeAt(i);
+    if (code > 0x20 && code !== 0x7f) {
+      result += value[i];
+    }
+  }
+  return result;
+}
+
+function sanitizeUrl(url: string | null | undefined): string {
+  if (!url) {
+    return "";
+  }
+
+  const trimmed = url.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  const normalized = stripControlsAndWhitespace(
+    decodeUrlForSchemeCheck(trimmed),
+  );
+  if (!normalized) {
+    return "";
+  }
+
+  if (normalized.startsWith("//")) {
+    return "";
+  }
+
+  if (!/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(normalized)) {
+    return trimmed;
+  }
+
+  try {
+    const parsed = new URL(normalized);
+    if (
+      parsed.protocol === "http:" ||
+      parsed.protocol === "https:" ||
+      parsed.protocol === "mailto:"
+    ) {
+      return normalized;
+    }
+  } catch {
+    return "";
+  }
+
+  return "";
+}
+
 // ============================================================================
 // Markdown Renderer
 // ============================================================================
@@ -236,7 +304,8 @@ function escapeHtml(html: string): string {
 const markdownRenderer = new marked.Renderer();
 
 markdownRenderer.code = ({ text, lang = "", escaped }: Tokens.Code): string => {
-  const languageClass = lang ? `language-${lang}` : "";
+  const safeLang = /^[a-zA-Z0-9_-]+$/.test(lang) ? lang : "";
+  const languageClass = safeLang ? `language-${safeLang}` : "";
   const safeCode = escaped ? text : escapeHtml(text);
   const encodedCode = encodeURIComponent(text);
 
@@ -265,12 +334,29 @@ markdownRenderer.code = ({ text, lang = "", escaped }: Tokens.Code): string => {
 };
 
 markdownRenderer.link = ({ href, title, text }: Tokens.Link): string => {
-  const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
-  const hrefAttr = href ? escapeHtml(href) : "";
-  const textContent = text || "";
+  const safeHref = escapeHtml(sanitizeUrl(href));
+  const textEscaped = escapeHtml(text);
 
-  return `<a href="${hrefAttr}" target="_blank" rel="noopener noreferrer"${titleAttr}>${textContent}</a>`;
+  if (!safeHref) {
+    return textEscaped;
+  }
+
+  const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
+  return `<a href="${safeHref}" target="_blank" rel="noopener noreferrer"${titleAttr}>${textEscaped}</a>`;
 };
+
+markdownRenderer.image = ({ href, title, text }: Tokens.Image): string => {
+  const safeHref = escapeHtml(sanitizeUrl(href));
+  if (!safeHref) {
+    return escapeHtml(text);
+  }
+
+  const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
+  return `<img src="${safeHref}" alt="${escapeHtml(text)}"${titleAttr} />`;
+};
+
+markdownRenderer.html = ({ text }: Tokens.HTML | Tokens.Tag): string =>
+  escapeHtml(text);
 
 // ============================================================================
 // Icon Components

--- a/apps/docs/src/registry/experiences/search-askai/components/search-ai.tsx
+++ b/apps/docs/src/registry/experiences/search-askai/components/search-ai.tsx
@@ -341,10 +341,17 @@ markdownRenderer.link = ({ href, title, text }: Tokens.Link): string => {
     return textEscaped;
   }
 
-  const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
+  const titleAttr = title ? ' title="' + escapeHtml(title) + '"' : "";
   // href/text/title are sanitized + escaped above.
-  // nosemgrep: javascript.lang.security.audit.raw-html-format
-  return `<a href="${safeHref}" target="_blank" rel="noopener noreferrer"${titleAttr}>${textEscaped}</a>`;
+  return (
+    '<a href="' +
+    safeHref +
+    '" target="_blank" rel="noopener noreferrer"' +
+    titleAttr +
+    ">" +
+    textEscaped +
+    "</a>"
+  ); // nosemgrep
 };
 
 markdownRenderer.image = ({ href, title, text }: Tokens.Image): string => {
@@ -353,10 +360,17 @@ markdownRenderer.image = ({ href, title, text }: Tokens.Image): string => {
     return escapeHtml(text);
   }
 
-  const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
+  const titleAttr = title ? ' title="' + escapeHtml(title) + '"' : "";
   // src/alt/title are sanitized + escaped above.
-  // nosemgrep: javascript.lang.security.audit.raw-html-format
-  return `<img src="${safeHref}" alt="${escapeHtml(text)}"${titleAttr} />`;
+  return (
+    '<img src="' +
+    safeHref +
+    '" alt="' +
+    escapeHtml(text) +
+    '"' +
+    titleAttr +
+    " />"
+  ); // nosemgrep
 };
 
 markdownRenderer.html = ({ text }: Tokens.HTML | Tokens.Tag): string =>
@@ -641,9 +655,8 @@ const MemoizedMarkdown = memo(function MemoizedMarkdown({
         [&_hr]:border-none [&_hr]:border-t [&_hr]:border-border [&_hr]:my-6
         [&_img]:max-w-full [&_img]:h-auto [&_img]:rounded-md [&_img]:my-2
         ${className}`.trim()}
-      // nosemgrep: javascript.react.security.audit.react-dangerouslysetinnerhtml
       // biome-ignore lint/security/noDangerouslySetInnerHtml: HTML escaped via marked renderer (html/link/image)
-      dangerouslySetInnerHTML={{ __html: html }}
+      dangerouslySetInnerHTML={{ __html: html }} // nosemgrep
     />
   );
 });

--- a/apps/docs/src/registry/experiences/search-askai/components/search-ai.tsx
+++ b/apps/docs/src/registry/experiences/search-askai/components/search-ai.tsx
@@ -301,6 +301,7 @@ function sanitizeUrl(url: string | null | undefined): string {
 // Markdown Renderer
 // ============================================================================
 
+/* eslint-disable xss/no-mixed-html -- marked renderer: interpolations escaped/sanitized */
 const markdownRenderer = new marked.Renderer();
 
 markdownRenderer.code = ({ text, lang = "", escaped }: Tokens.Code): string => {
@@ -375,6 +376,7 @@ markdownRenderer.image = ({ href, title, text }: Tokens.Image): string => {
 
 markdownRenderer.html = ({ text }: Tokens.HTML | Tokens.Tag): string =>
   escapeHtml(text);
+/* eslint-enable xss/no-mixed-html */
 
 // ============================================================================
 // Icon Components
@@ -656,7 +658,8 @@ const MemoizedMarkdown = memo(function MemoizedMarkdown({
         [&_img]:max-w-full [&_img]:h-auto [&_img]:rounded-md [&_img]:my-2
         ${className}`.trim()}
       // biome-ignore lint/security/noDangerouslySetInnerHtml: HTML escaped via marked renderer (html/link/image)
-      dangerouslySetInnerHTML={{ __html: html }} // nosemgrep
+      // eslint-disable-next-line xss/no-mixed-html -- sanitized marked output
+      dangerouslySetInnerHTML={{ __html: html }}
     />
   );
 });

--- a/apps/docs/src/registry/experiences/search-askai/components/search-ai.tsx
+++ b/apps/docs/src/registry/experiences/search-askai/components/search-ai.tsx
@@ -657,8 +657,8 @@ const MemoizedMarkdown = memo(function MemoizedMarkdown({
         [&_hr]:border-none [&_hr]:border-t [&_hr]:border-border [&_hr]:my-6
         [&_img]:max-w-full [&_img]:h-auto [&_img]:rounded-md [&_img]:my-2
         ${className}`.trim()}
-      // biome-ignore lint/security/noDangerouslySetInnerHtml: HTML escaped via marked renderer (html/link/image)
       // eslint-disable-next-line xss/no-mixed-html -- sanitized marked output
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: HTML escaped via marked renderer (html/link/image)
       dangerouslySetInnerHTML={{ __html: html }}
     />
   );

--- a/apps/docs/src/registry/experiences/search-askai/components/search-ai.tsx
+++ b/apps/docs/src/registry/experiences/search-askai/components/search-ai.tsx
@@ -250,7 +250,7 @@ function stripControlsAndWhitespace(value: string): string {
   for (let i = 0; i < value.length; i += 1) {
     const code = value.charCodeAt(i);
     if (code > 0x20 && code !== 0x7f) {
-      result += value[i];
+      result += value.charAt(i);
     }
   }
   return result;
@@ -342,6 +342,8 @@ markdownRenderer.link = ({ href, title, text }: Tokens.Link): string => {
   }
 
   const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
+  // href/text/title are sanitized + escaped above.
+  // nosemgrep: javascript.lang.security.audit.raw-html-format
   return `<a href="${safeHref}" target="_blank" rel="noopener noreferrer"${titleAttr}>${textEscaped}</a>`;
 };
 
@@ -352,6 +354,8 @@ markdownRenderer.image = ({ href, title, text }: Tokens.Image): string => {
   }
 
   const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
+  // src/alt/title are sanitized + escaped above.
+  // nosemgrep: javascript.lang.security.audit.raw-html-format
   return `<img src="${safeHref}" alt="${escapeHtml(text)}"${titleAttr} />`;
 };
 
@@ -637,7 +641,8 @@ const MemoizedMarkdown = memo(function MemoizedMarkdown({
         [&_hr]:border-none [&_hr]:border-t [&_hr]:border-border [&_hr]:my-6
         [&_img]:max-w-full [&_img]:h-auto [&_img]:rounded-md [&_img]:my-2
         ${className}`.trim()}
-      // biome-ignore lint/security/noDangerouslySetInnerHtml: its alright :)
+      // nosemgrep: javascript.react.security.audit.react-dangerouslysetinnerhtml
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: HTML escaped via marked renderer (html/link/image)
       dangerouslySetInnerHTML={{ __html: html }}
     />
   );

--- a/apps/docs/src/registry/experiences/search-askai/components/search-ai.tsx
+++ b/apps/docs/src/registry/experiences/search-askai/components/search-ai.tsx
@@ -266,13 +266,16 @@ function sanitizeUrl(url: string | null | undefined): string {
     return "";
   }
 
+  // Decode / strip controls for scheme checks only — return the original trimmed
+  // URL when safe so percent-encoding in the path/query is preserved.
   const normalized = stripControlsAndWhitespace(
     decodeUrlForSchemeCheck(trimmed),
-  );
+  ).replace(/\\/g, "/");
   if (!normalized) {
     return "";
   }
 
+  // Protocol-relative and backslash-obfuscated hosts (e.g. /\evil.com → //evil.com).
   if (normalized.startsWith("//")) {
     return "";
   }
@@ -288,7 +291,7 @@ function sanitizeUrl(url: string | null | undefined): string {
       parsed.protocol === "https:" ||
       parsed.protocol === "mailto:"
     ) {
-      return normalized;
+      return trimmed;
     }
   } catch {
     return "";

--- a/apps/docs/src/registry/experiences/sidepanel-askai/components/sidepanel-askai.tsx
+++ b/apps/docs/src/registry/experiences/sidepanel-askai/components/sidepanel-askai.tsx
@@ -289,6 +289,7 @@ function extractLinksFromMessage(message: Message | null): ExtractedLink[] {
 // Markdown Renderer
 // ============================================================================
 
+/* eslint-disable xss/no-mixed-html -- marked renderer: interpolations escaped/sanitized */
 const markdownRenderer = new marked.Renderer();
 
 markdownRenderer.code = ({ text, lang = "", escaped }: Tokens.Code): string => {
@@ -363,6 +364,7 @@ markdownRenderer.image = ({ href, title, text }: Tokens.Image): string => {
 
 markdownRenderer.html = ({ text }: Tokens.HTML | Tokens.Tag): string =>
   escapeHtml(text);
+/* eslint-enable xss/no-mixed-html */
 
 // ============================================================================
 // Icon Components
@@ -569,7 +571,8 @@ const MemoizedMarkdown = memo(function MemoizedMarkdown({
         [&_img]:max-w-full [&_img]:h-auto [&_img]:rounded-md [&_img]:my-2
         ${className}`.trim()}
       // biome-ignore lint/security/noDangerouslySetInnerHtml: HTML escaped via marked renderer (html/link/image)
-      dangerouslySetInnerHTML={{ __html: html }} // nosemgrep
+      // eslint-disable-next-line xss/no-mixed-html -- sanitized marked output
+      dangerouslySetInnerHTML={{ __html: html }}
     />
   );
 });

--- a/apps/docs/src/registry/experiences/sidepanel-askai/components/sidepanel-askai.tsx
+++ b/apps/docs/src/registry/experiences/sidepanel-askai/components/sidepanel-askai.tsx
@@ -177,13 +177,16 @@ function sanitizeUrl(url: string | null | undefined): string {
     return "";
   }
 
+  // Decode / strip controls for scheme checks only — return the original trimmed
+  // URL when safe so percent-encoding in the path/query is preserved.
   const normalized = stripControlsAndWhitespace(
     decodeUrlForSchemeCheck(trimmed),
-  );
+  ).replace(/\\/g, "/");
   if (!normalized) {
     return "";
   }
 
+  // Protocol-relative and backslash-obfuscated hosts (e.g. /\evil.com → //evil.com).
   if (normalized.startsWith("//")) {
     return "";
   }
@@ -199,7 +202,7 @@ function sanitizeUrl(url: string | null | undefined): string {
       parsed.protocol === "https:" ||
       parsed.protocol === "mailto:"
     ) {
-      return normalized;
+      return trimmed;
     }
   } catch {
     return "";

--- a/apps/docs/src/registry/experiences/sidepanel-askai/components/sidepanel-askai.tsx
+++ b/apps/docs/src/registry/experiences/sidepanel-askai/components/sidepanel-askai.tsx
@@ -570,8 +570,8 @@ const MemoizedMarkdown = memo(function MemoizedMarkdown({
         [&_hr]:border-none [&_hr]:border-t [&_hr]:border-border [&_hr]:my-6
         [&_img]:max-w-full [&_img]:h-auto [&_img]:rounded-md [&_img]:my-2
         ${className}`.trim()}
-      // biome-ignore lint/security/noDangerouslySetInnerHtml: HTML escaped via marked renderer (html/link/image)
       // eslint-disable-next-line xss/no-mixed-html -- sanitized marked output
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: HTML escaped via marked renderer (html/link/image)
       dangerouslySetInnerHTML={{ __html: html }}
     />
   );

--- a/apps/docs/src/registry/experiences/sidepanel-askai/components/sidepanel-askai.tsx
+++ b/apps/docs/src/registry/experiences/sidepanel-askai/components/sidepanel-askai.tsx
@@ -140,6 +140,74 @@ function escapeHtml(html: string): string {
     .replace(/'/g, "&#39;");
 }
 
+function decodeUrlForSchemeCheck(value: string): string {
+  let current = value;
+  for (let i = 0; i < 3; i += 1) {
+    try {
+      const decoded = decodeURIComponent(current);
+      if (decoded === current) {
+        break;
+      }
+      current = decoded;
+    } catch {
+      break;
+    }
+  }
+  return current;
+}
+
+function stripControlsAndWhitespace(value: string): string {
+  let result = "";
+  for (let i = 0; i < value.length; i += 1) {
+    const code = value.charCodeAt(i);
+    if (code > 0x20 && code !== 0x7f) {
+      result += value[i];
+    }
+  }
+  return result;
+}
+
+function sanitizeUrl(url: string | null | undefined): string {
+  if (!url) {
+    return "";
+  }
+
+  const trimmed = url.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  const normalized = stripControlsAndWhitespace(
+    decodeUrlForSchemeCheck(trimmed),
+  );
+  if (!normalized) {
+    return "";
+  }
+
+  if (normalized.startsWith("//")) {
+    return "";
+  }
+
+  if (!/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(normalized)) {
+    return trimmed;
+  }
+
+  try {
+    const parsed = new URL(normalized);
+    if (
+      parsed.protocol === "http:" ||
+      parsed.protocol === "https:" ||
+      parsed.protocol === "mailto:"
+    ) {
+      return normalized;
+    }
+  } catch {
+    return "";
+  }
+
+  return "";
+}
+
 function extractLinksFromMessage(message: Message | null): ExtractedLink[] {
   const links: ExtractedLink[] = [];
 
@@ -182,10 +250,10 @@ function extractLinksFromMessage(message: Message | null): ExtractedLink[] {
     // Parses the title and url from the found links
     for (const match of markdownMatches) {
       const title = match[1].trim();
-      const url = match[2];
+      const url = sanitizeUrl(match[2]);
 
       // Skip image URLs
-      if (imageUrls.has(url)) {
+      if (!url || imageUrls.has(url) || imageUrls.has(match[2])) {
         continue;
       }
 
@@ -200,10 +268,10 @@ function extractLinksFromMessage(message: Message | null): ExtractedLink[] {
 
     for (const match of plainUrls) {
       // Strip any extra punctuation
-      const cleanUrl = match[0].replace(/[.,;:!?]+$/, "");
+      const cleanUrl = sanitizeUrl(match[0].replace(/[.,;:!?]+$/, ""));
 
       // Skip image URLs
-      if (imageUrls.has(cleanUrl)) {
+      if (!cleanUrl || imageUrls.has(cleanUrl)) {
         continue;
       }
 
@@ -224,7 +292,8 @@ function extractLinksFromMessage(message: Message | null): ExtractedLink[] {
 const markdownRenderer = new marked.Renderer();
 
 markdownRenderer.code = ({ text, lang = "", escaped }: Tokens.Code): string => {
-  const languageClass = lang ? `language-${lang}` : "";
+  const safeLang = /^[a-zA-Z0-9_-]+$/.test(lang) ? lang : "";
+  const languageClass = safeLang ? `language-${safeLang}` : "";
   const safeCode = escaped ? text : escapeHtml(text);
   const encodedCode = encodeURIComponent(text);
 
@@ -253,12 +322,29 @@ markdownRenderer.code = ({ text, lang = "", escaped }: Tokens.Code): string => {
 };
 
 markdownRenderer.link = ({ href, title, text }: Tokens.Link): string => {
-  const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
-  const hrefAttr = href ? escapeHtml(href) : "";
-  const textContent = text || "";
+  const safeHref = escapeHtml(sanitizeUrl(href));
+  const textEscaped = escapeHtml(text);
 
-  return `<a href="${hrefAttr}" target="_blank" rel="noopener noreferrer"${titleAttr}>${textContent}</a>`;
+  if (!safeHref) {
+    return textEscaped;
+  }
+
+  const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
+  return `<a href="${safeHref}" target="_blank" rel="noopener noreferrer"${titleAttr}>${textEscaped}</a>`;
 };
+
+markdownRenderer.image = ({ href, title, text }: Tokens.Image): string => {
+  const safeHref = escapeHtml(sanitizeUrl(href));
+  if (!safeHref) {
+    return escapeHtml(text);
+  }
+
+  const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
+  return `<img src="${safeHref}" alt="${escapeHtml(text)}"${titleAttr} />`;
+};
+
+markdownRenderer.html = ({ text }: Tokens.HTML | Tokens.Tag): string =>
+  escapeHtml(text);
 
 // ============================================================================
 // Icon Components

--- a/apps/docs/src/registry/experiences/sidepanel-askai/components/sidepanel-askai.tsx
+++ b/apps/docs/src/registry/experiences/sidepanel-askai/components/sidepanel-askai.tsx
@@ -161,7 +161,7 @@ function stripControlsAndWhitespace(value: string): string {
   for (let i = 0; i < value.length; i += 1) {
     const code = value.charCodeAt(i);
     if (code > 0x20 && code !== 0x7f) {
-      result += value[i];
+      result += value.charAt(i);
     }
   }
   return result;
@@ -330,6 +330,8 @@ markdownRenderer.link = ({ href, title, text }: Tokens.Link): string => {
   }
 
   const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
+  // href/text/title are sanitized + escaped above.
+  // nosemgrep: javascript.lang.security.audit.raw-html-format
   return `<a href="${safeHref}" target="_blank" rel="noopener noreferrer"${titleAttr}>${textEscaped}</a>`;
 };
 
@@ -340,6 +342,8 @@ markdownRenderer.image = ({ href, title, text }: Tokens.Image): string => {
   }
 
   const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
+  // src/alt/title are sanitized + escaped above.
+  // nosemgrep: javascript.lang.security.audit.raw-html-format
   return `<img src="${safeHref}" alt="${escapeHtml(text)}"${titleAttr} />`;
 };
 
@@ -550,7 +554,8 @@ const MemoizedMarkdown = memo(function MemoizedMarkdown({
         [&_hr]:border-none [&_hr]:border-t [&_hr]:border-border [&_hr]:my-6
         [&_img]:max-w-full [&_img]:h-auto [&_img]:rounded-md [&_img]:my-2
         ${className}`.trim()}
-      // biome-ignore lint/security/noDangerouslySetInnerHtml: its alright :)
+      // nosemgrep: javascript.react.security.audit.react-dangerouslysetinnerhtml
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: HTML escaped via marked renderer (html/link/image)
       dangerouslySetInnerHTML={{ __html: html }}
     />
   );

--- a/apps/docs/src/registry/experiences/sidepanel-askai/components/sidepanel-askai.tsx
+++ b/apps/docs/src/registry/experiences/sidepanel-askai/components/sidepanel-askai.tsx
@@ -329,10 +329,17 @@ markdownRenderer.link = ({ href, title, text }: Tokens.Link): string => {
     return textEscaped;
   }
 
-  const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
+  const titleAttr = title ? ' title="' + escapeHtml(title) + '"' : "";
   // href/text/title are sanitized + escaped above.
-  // nosemgrep: javascript.lang.security.audit.raw-html-format
-  return `<a href="${safeHref}" target="_blank" rel="noopener noreferrer"${titleAttr}>${textEscaped}</a>`;
+  return (
+    '<a href="' +
+    safeHref +
+    '" target="_blank" rel="noopener noreferrer"' +
+    titleAttr +
+    ">" +
+    textEscaped +
+    "</a>"
+  ); // nosemgrep
 };
 
 markdownRenderer.image = ({ href, title, text }: Tokens.Image): string => {
@@ -341,10 +348,17 @@ markdownRenderer.image = ({ href, title, text }: Tokens.Image): string => {
     return escapeHtml(text);
   }
 
-  const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
+  const titleAttr = title ? ' title="' + escapeHtml(title) + '"' : "";
   // src/alt/title are sanitized + escaped above.
-  // nosemgrep: javascript.lang.security.audit.raw-html-format
-  return `<img src="${safeHref}" alt="${escapeHtml(text)}"${titleAttr} />`;
+  return (
+    '<img src="' +
+    safeHref +
+    '" alt="' +
+    escapeHtml(text) +
+    '"' +
+    titleAttr +
+    " />"
+  ); // nosemgrep
 };
 
 markdownRenderer.html = ({ text }: Tokens.HTML | Tokens.Tag): string =>
@@ -554,9 +568,8 @@ const MemoizedMarkdown = memo(function MemoizedMarkdown({
         [&_hr]:border-none [&_hr]:border-t [&_hr]:border-border [&_hr]:my-6
         [&_img]:max-w-full [&_img]:h-auto [&_img]:rounded-md [&_img]:my-2
         ${className}`.trim()}
-      // nosemgrep: javascript.react.security.audit.react-dangerouslysetinnerhtml
       // biome-ignore lint/security/noDangerouslySetInnerHtml: HTML escaped via marked renderer (html/link/image)
-      dangerouslySetInnerHTML={{ __html: html }}
+      dangerouslySetInnerHTML={{ __html: html }} // nosemgrep
     />
   );
 });

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -18,6 +18,7 @@
     "clean": "rm -rf dist",
     "dev": "rolldown -w -c rolldown.config.js",
     "prepublishOnly": "bun run clean && bun run build",
+    "test": "bun test src",
     "version": "bun pm version"
   },
   "dependencies": {

--- a/packages/standalone/src/components/search-askai/markdown.tsx
+++ b/packages/standalone/src/components/search-askai/markdown.tsx
@@ -13,8 +13,7 @@ export const MemoizedMarkdown = memo(function MemoizedMarkdown({
   const containerRef = useRef<HTMLDivElement>(null);
 
   // HTML is produced by parseMarkdownToSafeHtml (escapes raw HTML, sanitizes URLs).
-  // nosemgrep: javascript.lang.security.audit.xss-via-html
-  const html = useMemo(() => parseMarkdownToSafeHtml(children), [children]);
+  const html = useMemo(() => parseMarkdownToSafeHtml(children), [children]); // nosemgrep
 
   // Handle copy button clicks
   // biome-ignore lint/correctness/useExhaustiveDependencies: expected
@@ -63,9 +62,8 @@ export const MemoizedMarkdown = memo(function MemoizedMarkdown({
     <div
       ref={containerRef}
       className={`ss-markdown-content ${className}`.trim()}
-      // nosemgrep: javascript.react.security.audit.react-dangerouslysetinnerhtml
       // biome-ignore lint/security/noDangerouslySetInnerHtml: HTML is sanitized via parseMarkdownToSafeHtml
-      dangerouslySetInnerHTML={{ __html: html }}
+      dangerouslySetInnerHTML={{ __html: html }} // nosemgrep
     />
   );
 });

--- a/packages/standalone/src/components/search-askai/markdown.tsx
+++ b/packages/standalone/src/components/search-askai/markdown.tsx
@@ -13,7 +13,8 @@ export const MemoizedMarkdown = memo(function MemoizedMarkdown({
   const containerRef = useRef<HTMLDivElement>(null);
 
   // HTML is produced by parseMarkdownToSafeHtml (escapes raw HTML, sanitizes URLs).
-  const html = useMemo(() => parseMarkdownToSafeHtml(children), [children]); // nosemgrep
+  // eslint-disable-next-line xss/no-mixed-html -- sanitized via parseMarkdownToSafeHtml
+  const html = useMemo(() => parseMarkdownToSafeHtml(children), [children]);
 
   // Handle copy button clicks
   // biome-ignore lint/correctness/useExhaustiveDependencies: expected
@@ -63,7 +64,8 @@ export const MemoizedMarkdown = memo(function MemoizedMarkdown({
       ref={containerRef}
       className={`ss-markdown-content ${className}`.trim()}
       // biome-ignore lint/security/noDangerouslySetInnerHtml: HTML is sanitized via parseMarkdownToSafeHtml
-      dangerouslySetInnerHTML={{ __html: html }} // nosemgrep
+      // eslint-disable-next-line xss/no-mixed-html -- sanitized via parseMarkdownToSafeHtml
+      dangerouslySetInnerHTML={{ __html: html }}
     />
   );
 });

--- a/packages/standalone/src/components/search-askai/markdown.tsx
+++ b/packages/standalone/src/components/search-askai/markdown.tsx
@@ -12,6 +12,8 @@ export const MemoizedMarkdown = memo(function MemoizedMarkdown({
 }: MemoizedMarkdownProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
+  // HTML is produced by parseMarkdownToSafeHtml (escapes raw HTML, sanitizes URLs).
+  // nosemgrep: javascript.lang.security.audit.xss-via-html
   const html = useMemo(() => parseMarkdownToSafeHtml(children), [children]);
 
   // Handle copy button clicks
@@ -61,6 +63,7 @@ export const MemoizedMarkdown = memo(function MemoizedMarkdown({
     <div
       ref={containerRef}
       className={`ss-markdown-content ${className}`.trim()}
+      // nosemgrep: javascript.react.security.audit.react-dangerouslysetinnerhtml
       // biome-ignore lint/security/noDangerouslySetInnerHtml: HTML is sanitized via parseMarkdownToSafeHtml
       dangerouslySetInnerHTML={{ __html: html }}
     />

--- a/packages/standalone/src/components/search-askai/markdown.tsx
+++ b/packages/standalone/src/components/search-askai/markdown.tsx
@@ -63,8 +63,8 @@ export const MemoizedMarkdown = memo(function MemoizedMarkdown({
     <div
       ref={containerRef}
       className={`ss-markdown-content ${className}`.trim()}
-      // biome-ignore lint/security/noDangerouslySetInnerHtml: HTML is sanitized via parseMarkdownToSafeHtml
       // eslint-disable-next-line xss/no-mixed-html -- sanitized via parseMarkdownToSafeHtml
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: HTML is sanitized via parseMarkdownToSafeHtml
       dangerouslySetInnerHTML={{ __html: html }}
     />
   );

--- a/packages/standalone/src/components/search-askai/markdown.tsx
+++ b/packages/standalone/src/components/search-askai/markdown.tsx
@@ -1,84 +1,10 @@
-import { marked, type Tokens } from "marked";
 import { memo, useEffect, useMemo, useRef } from "react";
+import { parseMarkdownToSafeHtml } from "./utils/markdown";
 
 interface MemoizedMarkdownProps {
   children: string;
   className?: string;
 }
-
-/** Replace unpaired UTF-16 surrogates (common in crawled index text). */
-function replaceUnpairedSurrogates(value: string): string {
-  return value.replace(
-    /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g,
-    "\uFFFD",
-  );
-}
-
-function toMarkdownString(value: unknown): string {
-  if (typeof value !== "string") return "";
-  return replaceUnpairedSurrogates(value);
-}
-
-function safeEncodeURIComponent(value: string): string {
-  const sanitized = replaceUnpairedSurrogates(value);
-  try {
-    return encodeURIComponent(sanitized);
-  } catch {
-    return "";
-  }
-}
-
-// Escape HTML special characters for safe insertion
-function escapeHtml(html: string): string {
-  return toMarkdownString(html)
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
-}
-
-// Create a custom renderer
-const renderer = new marked.Renderer();
-
-// Custom code block renderer with copy functionality
-renderer.code = ({ text, lang = "", escaped }: Tokens.Code): string => {
-  const languageClass = lang ? `language-${lang}` : "";
-  const safeCode = escaped ? text : escapeHtml(text);
-  const encodedCode = safeEncodeURIComponent(text);
-
-  const copyIconSvg = `
-    <svg class="ss-markdown-copy-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-      <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
-      <path d="m5 15-4-4 4-4"></path>
-    </svg>
-  `;
-
-  const checkIconSvg = `
-    <svg class="ss-markdown-check-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-      <polyline points="20,6 9,17 4,12"></polyline>
-    </svg>
-  `;
-
-  return `
-    <div class="ss-markdown-code-snippet">
-      <button class="ss-markdown-copy-button" data-code="${encodedCode}" aria-label="Copy code to clipboard" title="Copy code">
-        ${copyIconSvg}${checkIconSvg}
-        <span class="ss-markdown-copy-label">Copy</span>
-      </button>
-      <pre><code class="${languageClass}">${safeCode}</code></pre>
-    </div>
-  `;
-};
-
-// Ensure markdown links open in new tab with security attributes
-renderer.link = ({ href, title, text }: Tokens.Link): string => {
-  const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
-  const hrefAttr = href ? escapeHtml(href) : "";
-  const textContent = text || "";
-
-  return `<a href="${hrefAttr}" target="_blank" rel="noopener noreferrer"${titleAttr}>${textContent}</a>`;
-};
 
 export const MemoizedMarkdown = memo(function MemoizedMarkdown({
   children,
@@ -86,19 +12,7 @@ export const MemoizedMarkdown = memo(function MemoizedMarkdown({
 }: MemoizedMarkdownProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const html = useMemo(() => {
-    const source = toMarkdownString(children);
-    try {
-      return marked(source, {
-        renderer,
-        breaks: true,
-        gfm: true,
-      });
-    } catch (error) {
-      console.error("Error parsing markdown:", error);
-      return escapeHtml(source);
-    }
-  }, [children]);
+  const html = useMemo(() => parseMarkdownToSafeHtml(children), [children]);
 
   // Handle copy button clicks
   // biome-ignore lint/correctness/useExhaustiveDependencies: expected
@@ -147,7 +61,7 @@ export const MemoizedMarkdown = memo(function MemoizedMarkdown({
     <div
       ref={containerRef}
       className={`ss-markdown-content ${className}`.trim()}
-      // biome-ignore lint/security/noDangerouslySetInnerHtml: its alright :)
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: HTML is sanitized via parseMarkdownToSafeHtml
       dangerouslySetInnerHTML={{ __html: html }}
     />
   );

--- a/packages/standalone/src/components/search-askai/utils/__tests__/markdown.test.ts
+++ b/packages/standalone/src/components/search-askai/utils/__tests__/markdown.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "bun:test";
+import { parseMarkdownToSafeHtml } from "../markdown";
+
+describe("parseMarkdownToSafeHtml", () => {
+  it("escapes raw HTML so event handlers cannot run", () => {
+    const html = parseMarkdownToSafeHtml('<img src=x onerror=alert(1)>');
+    expect(html).not.toMatch(/<img\b/i);
+    expect(html).toContain("&lt;img");
+    expect(html).toBe("&lt;img src=x onerror=alert(1)&gt;");
+  });
+
+  it("escapes inline script tags", () => {
+    const html = parseMarkdownToSafeHtml("a <script>alert(1)</script> b");
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  it("does not emit javascript: links", () => {
+    const html = parseMarkdownToSafeHtml(`[click](javascript${":"}alert(1))`);
+    expect(html).not.toContain(`javascript${":"}`);
+    expect(html).not.toContain("<a ");
+    expect(html).toContain("click");
+  });
+
+  it("does not emit javascript: images", () => {
+    const html = parseMarkdownToSafeHtml(`![x](javascript${":"}alert(1))`);
+    expect(html).not.toContain(`javascript${":"}`);
+    expect(html).not.toContain("<img");
+  });
+
+  it("keeps safe markdown links and formatting", () => {
+    const html = parseMarkdownToSafeHtml(
+      "See [SiteSearch](https://www.algolia.com) and **bold**",
+    );
+    expect(html).toContain('href="https://www.algolia.com"');
+    expect(html).toContain('target="_blank"');
+    expect(html).toContain('rel="noopener noreferrer"');
+    expect(html).toContain("<strong>bold</strong>");
+  });
+
+  it("still renders fenced code blocks with escaped content", () => {
+    const html = parseMarkdownToSafeHtml('```js\nconst x = "<script>"\n```');
+    expect(html).toContain("ss-markdown-code-snippet");
+    expect(html).toContain("language-js");
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  it("does not allow HTML breakout via fenced-code lang", () => {
+    const html = parseMarkdownToSafeHtml(
+      '```"><img src=x onerror=alert(1)>\nx\n```',
+    );
+    expect(html).not.toMatch(/<img\b/i);
+    expect(html).not.toContain("onerror=alert");
+    expect(html).not.toContain('language-">');
+  });
+});

--- a/packages/standalone/src/components/search-askai/utils/__tests__/markdown.test.ts
+++ b/packages/standalone/src/components/search-askai/utils/__tests__/markdown.test.ts
@@ -3,7 +3,7 @@ import { parseMarkdownToSafeHtml } from "../markdown";
 
 describe("parseMarkdownToSafeHtml", () => {
   it("escapes raw HTML so event handlers cannot run", () => {
-    const html = parseMarkdownToSafeHtml('<img src=x onerror=alert(1)>');
+    const html = parseMarkdownToSafeHtml("<img src=x onerror=alert(1)>");
     expect(html).not.toMatch(/<img\b/i);
     expect(html).toContain("&lt;img");
     expect(html).toBe("&lt;img src=x onerror=alert(1)&gt;");

--- a/packages/standalone/src/components/search-askai/utils/__tests__/sanitize.test.ts
+++ b/packages/standalone/src/components/search-askai/utils/__tests__/sanitize.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "bun:test";
+import { escapeHtml, sanitizeUrl } from "../sanitize";
+
+describe("escapeHtml", () => {
+  it("escapes HTML special characters", () => {
+    expect(escapeHtml(`<img src="x" onerror='alert(1)'>`)).toBe(
+      "&lt;img src=&quot;x&quot; onerror=&#39;alert(1)&#39;&gt;",
+    );
+  });
+});
+
+describe("sanitizeUrl", () => {
+  it("allows http(s) and mailto URLs", () => {
+    expect(sanitizeUrl("https://docsearch.algolia.com")).toBe(
+      "https://docsearch.algolia.com",
+    );
+    expect(sanitizeUrl("http://example.com/path")).toBe(
+      "http://example.com/path",
+    );
+    expect(sanitizeUrl("mailto:docs@example.com")).toBe(
+      "mailto:docs@example.com",
+    );
+  });
+
+  it("allows relative paths and fragments", () => {
+    expect(sanitizeUrl("/docs/api")).toBe("/docs/api");
+    expect(sanitizeUrl("#section")).toBe("#section");
+    expect(sanitizeUrl("?q=1")).toBe("?q=1");
+    expect(sanitizeUrl("./relative")).toBe("./relative");
+  });
+
+  it("blocks javascript and other unsafe schemes", () => {
+    const jsAlert = `javascript${":"}alert(1)`;
+    expect(sanitizeUrl(jsAlert)).toBe("");
+    expect(sanitizeUrl(`JAVASCRIPT${":"}alert(1)`)).toBe("");
+    expect(sanitizeUrl("data:text/html,<script>alert(1)</script>")).toBe("");
+    expect(sanitizeUrl("vbscript:msgbox(1)")).toBe("");
+    expect(sanitizeUrl("//evil.example/path")).toBe("");
+  });
+
+  it("blocks schemes broken up by whitespace or control characters", () => {
+    expect(sanitizeUrl(`java\tscript${":"}alert(1)`)).toBe("");
+    expect(sanitizeUrl(`java\nscript${":"}alert(1)`)).toBe("");
+    expect(sanitizeUrl(`java\rscript${":"}alert(1)`)).toBe("");
+    expect(sanitizeUrl(`java script${":"}alert(1)`)).toBe("");
+    expect(sanitizeUrl(`java\u0000script${":"}alert(1)`)).toBe("");
+  });
+
+  it("blocks percent-encoded schemes", () => {
+    expect(sanitizeUrl("%6Aavascript:alert(1)")).toBe("");
+    expect(sanitizeUrl("%6aavascript:alert(1)")).toBe("");
+    expect(sanitizeUrl("java%09script:alert(1)")).toBe("");
+    expect(sanitizeUrl("java%0ascript:alert(1)")).toBe("");
+    expect(sanitizeUrl("%256Aavascript:alert(1)")).toBe("");
+  });
+});

--- a/packages/standalone/src/components/search-askai/utils/__tests__/sanitize.test.ts
+++ b/packages/standalone/src/components/search-askai/utils/__tests__/sanitize.test.ts
@@ -46,6 +46,18 @@ describe("sanitizeUrl", () => {
     expect(sanitizeUrl(`java\u0000script${":"}alert(1)`)).toBe("");
   });
 
+  it("blocks protocol-relative and backslash-obfuscated hosts", () => {
+    expect(sanitizeUrl("//evil.example/path")).toBe("");
+    expect(sanitizeUrl("/\\evil.example/path")).toBe("");
+    expect(sanitizeUrl("\\\\evil.example/path")).toBe("");
+  });
+
+  it("preserves percent-encoding in allowed http(s) URLs", () => {
+    expect(
+      sanitizeUrl("https://docs.example.com/api%20reference?tag=foo%26bar"),
+    ).toBe("https://docs.example.com/api%20reference?tag=foo%26bar");
+  });
+
   it("blocks percent-encoded schemes", () => {
     expect(sanitizeUrl("%6Aavascript:alert(1)")).toBe("");
     expect(sanitizeUrl("%6aavascript:alert(1)")).toBe("");

--- a/packages/standalone/src/components/search-askai/utils/markdown.ts
+++ b/packages/standalone/src/components/search-askai/utils/markdown.ts
@@ -26,36 +26,41 @@ function safeEncodeURIComponent(value: string): string {
 const renderer = new marked.Renderer();
 
 renderer.code = ({ text, lang = "", escaped }: Tokens.Code): string => {
+  // nosemgrep
   const safeLang = /^[a-zA-Z0-9_-]+$/.test(lang) ? lang : "";
   const languageClass = safeLang ? `language-${safeLang}` : "";
   const safeCode = escaped ? text : escapeHtml(text);
   const encodedCode = safeEncodeURIComponent(text);
 
-  const copyIconSvg = [
+  // Static SVG markup (no user input).
+  const copyIconHtml = [
+    // nosemgrep
     '<svg class="ss-markdown-copy-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">',
     '<rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>',
     '<path d="m5 15-4-4 4-4"></path>',
     "</svg>",
   ].join("");
 
-  const checkIconSvg = [
+  const checkIconHtml = [
+    // nosemgrep
     '<svg class="ss-markdown-check-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">',
     '<polyline points="20,6 9,17 4,12"></polyline>',
     "</svg>",
   ].join("");
 
-  // Values interpolated below are escaped / allowlisted (encodedCode, languageClass, safeCode).
-  // nosemgrep: javascript.lang.security.audit.raw-html-format
+  // encodedCode / languageClass / safeCode are escaped or allowlisted above.
   return [
     '<div class="ss-markdown-code-snippet">',
-    `<button class="ss-markdown-copy-button" data-code="${encodedCode}" aria-label="Copy code to clipboard" title="Copy code">`,
-    copyIconSvg,
-    checkIconSvg,
+    '<button class="ss-markdown-copy-button" data-code="' +
+      encodedCode +
+      '" aria-label="Copy code to clipboard" title="Copy code">',
+    copyIconHtml, // nosemgrep
+    checkIconHtml, // nosemgrep
     '<span class="ss-markdown-copy-label">Copy</span>',
     "</button>",
-    `<pre><code class="${languageClass}">${safeCode}</code></pre>`,
+    '<pre><code class="' + languageClass + '">' + safeCode + "</code></pre>",
     "</div>",
-  ].join("");
+  ].join(""); // nosemgrep
 };
 
 renderer.link = ({ href, title, text }: Tokens.Link): string => {
@@ -66,10 +71,17 @@ renderer.link = ({ href, title, text }: Tokens.Link): string => {
     return textEscaped;
   }
 
-  const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
+  const titleAttr = title ? ' title="' + escapeHtml(title) + '"' : "";
   // href/text/title are sanitized + escaped above.
-  // nosemgrep: javascript.lang.security.audit.raw-html-format
-  return `<a href="${safeHref}" target="_blank" rel="noopener noreferrer"${titleAttr}>${textEscaped}</a>`;
+  return (
+    '<a href="' +
+    safeHref +
+    '" target="_blank" rel="noopener noreferrer"' +
+    titleAttr +
+    ">" +
+    textEscaped +
+    "</a>"
+  ); // nosemgrep
 };
 
 renderer.image = ({ href, title, text }: Tokens.Image): string => {
@@ -78,10 +90,17 @@ renderer.image = ({ href, title, text }: Tokens.Image): string => {
     return escapeHtml(text);
   }
 
-  const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
+  const titleAttr = title ? ' title="' + escapeHtml(title) + '"' : "";
   // src/alt/title are sanitized + escaped above.
-  // nosemgrep: javascript.lang.security.audit.raw-html-format
-  return `<img src="${safeHref}" alt="${escapeHtml(text)}"${titleAttr} />`;
+  return (
+    '<img src="' +
+    safeHref +
+    '" alt="' +
+    escapeHtml(text) +
+    '"' +
+    titleAttr +
+    " />"
+  ); // nosemgrep
 };
 
 renderer.html = ({ text }: Tokens.HTML | Tokens.Tag): string =>

--- a/packages/standalone/src/components/search-askai/utils/markdown.ts
+++ b/packages/standalone/src/components/search-askai/utils/markdown.ts
@@ -31,28 +31,31 @@ renderer.code = ({ text, lang = "", escaped }: Tokens.Code): string => {
   const safeCode = escaped ? text : escapeHtml(text);
   const encodedCode = safeEncodeURIComponent(text);
 
-  const copyIconSvg = `
-    <svg class="ss-markdown-copy-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-      <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
-      <path d="m5 15-4-4 4-4"></path>
-    </svg>
-  `;
+  const copyIconSvg = [
+    '<svg class="ss-markdown-copy-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">',
+    '<rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>',
+    '<path d="m5 15-4-4 4-4"></path>',
+    "</svg>",
+  ].join("");
 
-  const checkIconSvg = `
-    <svg class="ss-markdown-check-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-      <polyline points="20,6 9,17 4,12"></polyline>
-    </svg>
-  `;
+  const checkIconSvg = [
+    '<svg class="ss-markdown-check-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">',
+    '<polyline points="20,6 9,17 4,12"></polyline>',
+    "</svg>",
+  ].join("");
 
-  return `
-    <div class="ss-markdown-code-snippet">
-      <button class="ss-markdown-copy-button" data-code="${encodedCode}" aria-label="Copy code to clipboard" title="Copy code">
-        ${copyIconSvg}${checkIconSvg}
-        <span class="ss-markdown-copy-label">Copy</span>
-      </button>
-      <pre><code class="${languageClass}">${safeCode}</code></pre>
-    </div>
-  `;
+  // Values interpolated below are escaped / allowlisted (encodedCode, languageClass, safeCode).
+  // nosemgrep: javascript.lang.security.audit.raw-html-format
+  return [
+    '<div class="ss-markdown-code-snippet">',
+    `<button class="ss-markdown-copy-button" data-code="${encodedCode}" aria-label="Copy code to clipboard" title="Copy code">`,
+    copyIconSvg,
+    checkIconSvg,
+    '<span class="ss-markdown-copy-label">Copy</span>',
+    "</button>",
+    `<pre><code class="${languageClass}">${safeCode}</code></pre>`,
+    "</div>",
+  ].join("");
 };
 
 renderer.link = ({ href, title, text }: Tokens.Link): string => {
@@ -64,6 +67,8 @@ renderer.link = ({ href, title, text }: Tokens.Link): string => {
   }
 
   const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
+  // href/text/title are sanitized + escaped above.
+  // nosemgrep: javascript.lang.security.audit.raw-html-format
   return `<a href="${safeHref}" target="_blank" rel="noopener noreferrer"${titleAttr}>${textEscaped}</a>`;
 };
 
@@ -74,6 +79,8 @@ renderer.image = ({ href, title, text }: Tokens.Image): string => {
   }
 
   const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
+  // src/alt/title are sanitized + escaped above.
+  // nosemgrep: javascript.lang.security.audit.raw-html-format
   return `<img src="${safeHref}" alt="${escapeHtml(text)}"${titleAttr} />`;
 };
 

--- a/packages/standalone/src/components/search-askai/utils/markdown.ts
+++ b/packages/standalone/src/components/search-askai/utils/markdown.ts
@@ -25,42 +25,38 @@ function safeEncodeURIComponent(value: string): string {
 
 const renderer = new marked.Renderer();
 
+/* eslint-disable xss/no-mixed-html -- marked renderer: all interpolations are escapeHtml/sanitizeUrl/allowlisted */
 renderer.code = ({ text, lang = "", escaped }: Tokens.Code): string => {
-  // nosemgrep
   const safeLang = /^[a-zA-Z0-9_-]+$/.test(lang) ? lang : "";
   const languageClass = safeLang ? `language-${safeLang}` : "";
   const safeCode = escaped ? text : escapeHtml(text);
   const encodedCode = safeEncodeURIComponent(text);
 
-  // Static SVG markup (no user input).
-  const copyIconHtml = [
-    // nosemgrep
+  const copyIconAsHtml = [
     '<svg class="ss-markdown-copy-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">',
     '<rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>',
     '<path d="m5 15-4-4 4-4"></path>',
     "</svg>",
   ].join("");
 
-  const checkIconHtml = [
-    // nosemgrep
+  const checkIconAsHtml = [
     '<svg class="ss-markdown-check-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">',
     '<polyline points="20,6 9,17 4,12"></polyline>',
     "</svg>",
   ].join("");
 
-  // encodedCode / languageClass / safeCode are escaped or allowlisted above.
   return [
     '<div class="ss-markdown-code-snippet">',
     '<button class="ss-markdown-copy-button" data-code="' +
       encodedCode +
       '" aria-label="Copy code to clipboard" title="Copy code">',
-    copyIconHtml, // nosemgrep
-    checkIconHtml, // nosemgrep
+    copyIconAsHtml,
+    checkIconAsHtml,
     '<span class="ss-markdown-copy-label">Copy</span>',
     "</button>",
     '<pre><code class="' + languageClass + '">' + safeCode + "</code></pre>",
     "</div>",
-  ].join(""); // nosemgrep
+  ].join("");
 };
 
 renderer.link = ({ href, title, text }: Tokens.Link): string => {
@@ -72,7 +68,6 @@ renderer.link = ({ href, title, text }: Tokens.Link): string => {
   }
 
   const titleAttr = title ? ' title="' + escapeHtml(title) + '"' : "";
-  // href/text/title are sanitized + escaped above.
   return (
     '<a href="' +
     safeHref +
@@ -81,7 +76,7 @@ renderer.link = ({ href, title, text }: Tokens.Link): string => {
     ">" +
     textEscaped +
     "</a>"
-  ); // nosemgrep
+  );
 };
 
 renderer.image = ({ href, title, text }: Tokens.Image): string => {
@@ -91,7 +86,6 @@ renderer.image = ({ href, title, text }: Tokens.Image): string => {
   }
 
   const titleAttr = title ? ' title="' + escapeHtml(title) + '"' : "";
-  // src/alt/title are sanitized + escaped above.
   return (
     '<img src="' +
     safeHref +
@@ -100,11 +94,12 @@ renderer.image = ({ href, title, text }: Tokens.Image): string => {
     '"' +
     titleAttr +
     " />"
-  ); // nosemgrep
+  );
 };
 
 renderer.html = ({ text }: Tokens.HTML | Tokens.Tag): string =>
   escapeHtml(text);
+/* eslint-enable xss/no-mixed-html */
 
 /** Parses markdown into HTML safe for `dangerouslySetInnerHTML`. */
 export function parseMarkdownToSafeHtml(content: string): string {

--- a/packages/standalone/src/components/search-askai/utils/markdown.ts
+++ b/packages/standalone/src/components/search-askai/utils/markdown.ts
@@ -1,0 +1,96 @@
+import { marked, type Tokens } from "marked";
+import { escapeHtml, sanitizeUrl } from "./sanitize";
+
+/** Replace unpaired UTF-16 surrogates (common in crawled index text). */
+function replaceUnpairedSurrogates(value: string): string {
+  return value.replace(
+    /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g,
+    "\uFFFD",
+  );
+}
+
+function toMarkdownString(value: unknown): string {
+  if (typeof value !== "string") return "";
+  return replaceUnpairedSurrogates(value);
+}
+
+function safeEncodeURIComponent(value: string): string {
+  const sanitized = replaceUnpairedSurrogates(value);
+  try {
+    return encodeURIComponent(sanitized);
+  } catch {
+    return "";
+  }
+}
+
+const renderer = new marked.Renderer();
+
+renderer.code = ({ text, lang = "", escaped }: Tokens.Code): string => {
+  const safeLang = /^[a-zA-Z0-9_-]+$/.test(lang) ? lang : "";
+  const languageClass = safeLang ? `language-${safeLang}` : "";
+  const safeCode = escaped ? text : escapeHtml(text);
+  const encodedCode = safeEncodeURIComponent(text);
+
+  const copyIconSvg = `
+    <svg class="ss-markdown-copy-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+      <path d="m5 15-4-4 4-4"></path>
+    </svg>
+  `;
+
+  const checkIconSvg = `
+    <svg class="ss-markdown-check-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <polyline points="20,6 9,17 4,12"></polyline>
+    </svg>
+  `;
+
+  return `
+    <div class="ss-markdown-code-snippet">
+      <button class="ss-markdown-copy-button" data-code="${encodedCode}" aria-label="Copy code to clipboard" title="Copy code">
+        ${copyIconSvg}${checkIconSvg}
+        <span class="ss-markdown-copy-label">Copy</span>
+      </button>
+      <pre><code class="${languageClass}">${safeCode}</code></pre>
+    </div>
+  `;
+};
+
+renderer.link = ({ href, title, text }: Tokens.Link): string => {
+  const safeHref = escapeHtml(sanitizeUrl(href));
+  const textEscaped = escapeHtml(text);
+
+  if (!safeHref) {
+    return textEscaped;
+  }
+
+  const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
+  return `<a href="${safeHref}" target="_blank" rel="noopener noreferrer"${titleAttr}>${textEscaped}</a>`;
+};
+
+renderer.image = ({ href, title, text }: Tokens.Image): string => {
+  const safeHref = escapeHtml(sanitizeUrl(href));
+  if (!safeHref) {
+    return escapeHtml(text);
+  }
+
+  const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
+  return `<img src="${safeHref}" alt="${escapeHtml(text)}"${titleAttr} />`;
+};
+
+renderer.html = ({ text }: Tokens.HTML | Tokens.Tag): string =>
+  escapeHtml(text);
+
+/** Parses markdown into HTML safe for `dangerouslySetInnerHTML`. */
+export function parseMarkdownToSafeHtml(content: string): string {
+  const source = toMarkdownString(content);
+  try {
+    return marked.parse(source, {
+      gfm: true,
+      breaks: true,
+      renderer,
+    }) as string;
+  } catch (error) {
+    console.error("Error parsing markdown:", error);
+    return escapeHtml(source);
+  }
+}

--- a/packages/standalone/src/components/search-askai/utils/sanitize.ts
+++ b/packages/standalone/src/components/search-askai/utils/sanitize.ts
@@ -51,13 +51,16 @@ export function sanitizeUrl(url: string | null | undefined): string {
     return "";
   }
 
+  // Decode / strip controls for scheme checks only — return the original trimmed
+  // URL when safe so percent-encoding in the path/query is preserved.
   const normalized = stripControlsAndWhitespace(
     decodeUrlForSchemeCheck(trimmed),
-  );
+  ).replace(/\\/g, "/");
   if (!normalized) {
     return "";
   }
 
+  // Protocol-relative and backslash-obfuscated hosts (e.g. /\evil.com → //evil.com).
   if (normalized.startsWith("//")) {
     return "";
   }
@@ -73,7 +76,7 @@ export function sanitizeUrl(url: string | null | undefined): string {
       parsed.protocol === "https:" ||
       parsed.protocol === "mailto:"
     ) {
-      return normalized;
+      return trimmed;
     }
   } catch {
     return "";

--- a/packages/standalone/src/components/search-askai/utils/sanitize.ts
+++ b/packages/standalone/src/components/search-askai/utils/sanitize.ts
@@ -25,11 +25,13 @@ function decodeUrlForSchemeCheck(value: string): string {
 }
 
 function stripControlsAndWhitespace(value: string): string {
+  // Strip ASCII controls + whitespace so scheme checks cannot be bypassed via
+  // `java\tscript:` / `java script:` style obfuscation.
   let result = "";
   for (let i = 0; i < value.length; i += 1) {
     const code = value.charCodeAt(i);
     if (code > 0x20 && code !== 0x7f) {
-      result += value[i];
+      result += value.charAt(i);
     }
   }
   return result;

--- a/packages/standalone/src/components/search-askai/utils/sanitize.ts
+++ b/packages/standalone/src/components/search-askai/utils/sanitize.ts
@@ -1,0 +1,81 @@
+/** Escapes HTML special characters for safe interpolation into HTML strings. */
+export function escapeHtml(unsafe: string): string {
+  return unsafe
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function decodeUrlForSchemeCheck(value: string): string {
+  let current = value;
+  for (let i = 0; i < 3; i += 1) {
+    try {
+      const decoded = decodeURIComponent(current);
+      if (decoded === current) {
+        break;
+      }
+      current = decoded;
+    } catch {
+      break;
+    }
+  }
+  return current;
+}
+
+function stripControlsAndWhitespace(value: string): string {
+  let result = "";
+  for (let i = 0; i < value.length; i += 1) {
+    const code = value.charCodeAt(i);
+    if (code > 0x20 && code !== 0x7f) {
+      result += value[i];
+    }
+  }
+  return result;
+}
+
+/**
+ * Returns a URL safe for href/src, or '' if unsafe.
+ * Does not HTML-escape — callers building HTML strings must escape separately.
+ */
+export function sanitizeUrl(url: string | null | undefined): string {
+  if (!url) {
+    return "";
+  }
+
+  const trimmed = url.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  const normalized = stripControlsAndWhitespace(
+    decodeUrlForSchemeCheck(trimmed),
+  );
+  if (!normalized) {
+    return "";
+  }
+
+  if (normalized.startsWith("//")) {
+    return "";
+  }
+
+  if (!/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(normalized)) {
+    return trimmed;
+  }
+
+  try {
+    const parsed = new URL(normalized);
+    if (
+      parsed.protocol === "http:" ||
+      parsed.protocol === "https:" ||
+      parsed.protocol === "mailto:"
+    ) {
+      return normalized;
+    }
+  } catch {
+    return "";
+  }
+
+  return "";
+}


### PR DESCRIPTION
## Summary
- SiteSearch Ask AI does **not** use `@docsearch/react` — it has its own `marked` → `dangerouslySetInnerHTML` path (`packages/standalone/.../markdown.tsx`), so DocSearch #2929 does not cover this product.
- Harden that sink (and docs registry copies): escape raw HTML, allowlist fenced-code langs, `sanitizeUrl` (block `javascript:`/`data:`/`vbscript:`, whitespace/control obfuscation, percent-encoded schemes), sanitize image/link hrefs.
- Docs sidepanel related-source extraction now runs links through `sanitizeUrl`.
- Unit tests cover the reported PoC and the bypass cases.

Fixes [SA-3822](https://algolia.atlassian.net/browse/SA-3822). Mirrors [docsearch#2929](https://github.com/algolia/docsearch/pull/2929).

## Test plan
- [ ] `bun --filter @algolia/sitesearch test`
- [ ] Ask AI: `Print <img src="x" onerror="alert(1)">` — HTML escaped, no alert
- [ ] Ask AI markdown link `[x](javascript:alert(1))` — no `javascript:` href
- [ ] Ask AI fenced code with hostile lang — no attribute breakout
- [ ] Docs sidepanel Related Sources — unsafe schemes omitted

[SA-3822]: https://algolia.atlassian.net/browse/SA-3822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ